### PR TITLE
docs(metricas): separa fichas em arquivos individuais e adiciona metrica de projeto

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Os itens abaixo são previstos no conceito completo do produto, mas estão exclu
 ### Estimativas e métricas
 
 - [Baseline](./docs/baseline.md)
-- [Métricas](./docs/metricas.md)
+- [Métricas](./docs/metricas/) — M1 a M5, com fichas individuais por métrica
 - [Estimativas](./docs/estimativas.md)
 
 ### Riscos e Consolidação (Entrega 4)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Os itens abaixo são previstos no conceito completo do produto, mas estão exclu
 ### Estimativas e métricas
 
 - [Baseline](./docs/baseline.md)
-- [Métricas](./docs/metricas/) — M1 a M5, com fichas individuais por métrica
+- [Métricas](./docs/metricas/) com fichas individuais para cada uma das 5 métricas definidas (M1 a M5)
 - [Estimativas](./docs/estimativas.md)
 
 ### Riscos e Consolidação (Entrega 4)

--- a/docs/metricas/README.md
+++ b/docs/metricas/README.md
@@ -1,0 +1,15 @@
+# Métricas do Projeto Librum
+
+As métricas estão organizadas em fichas individuais para facilitar a referenciação e o acompanhamento ao longo das sprints.
+
+O acompanhamento começa a partir do Sprint 1. Cada ficha registra data e valor coletado ao final de cada ciclo.
+
+## Índice
+
+| Código | Nome | Classificação | Arquivo |
+|--------|------|---------------|---------|
+| M1 | Cobertura de Testes Automatizados | Produto | [m1-cobertura-testes.md](./m1-cobertura-testes.md) |
+| M2 | Taxa de Erros em Produção | Produto | [m2-taxa-erros-producao.md](./m2-taxa-erros-producao.md) |
+| M3 | Tempo de Resposta das Requisições | Produto | [m3-tempo-resposta.md](./m3-tempo-resposta.md) |
+| M4 | Taxa de Aprovação de Pull Requests | Processo | [m4-taxa-aprovacao-prs.md](./m4-taxa-aprovacao-prs.md) |
+| M5 | Velocity por Sprint | **Projeto** | [m5-velocity.md](./m5-velocity.md) |

--- a/docs/metricas/m1-cobertura-testes.md
+++ b/docs/metricas/m1-cobertura-testes.md
@@ -2,15 +2,15 @@
 
 **Classificação:** Produto
 
-**Objetivo:** Garantir que o código está sendo testado de forma adequada.
+**Objetivo:** Verificar se o código está sendo coberto por testes em proporção suficiente para garantir segurança nas mudanças.
 
-**Como medir:** percentual de linhas cobertas por testes em relação ao total — (linhas cobertas / total de linhas) × 100.
+**Como medir:** percentual de linhas cobertas por testes em relação ao total, usando a fórmula (linhas cobertas / total de linhas) × 100.
 
 **Fonte:** relatório de cobertura gerado no CI a cada Pull Request.
 
 **Responsável:** Giuliano
 
-**Interpretação:** a meta mínima é 60%. Abaixo disso, o merge é bloqueado até cobrir o que está faltando.
+**Interpretação:** a meta mínima é 60%. Abaixo disso, o merge fica bloqueado até que a cobertura seja complementada.
 
 ---
 
@@ -18,4 +18,4 @@
 
 | Data       | Valor coletado | Observação                        |
 |------------|---------------|-----------------------------------|
-| 06/04/2026 | —             | Sprint 1 ainda não iniciado. Coleta começa após o primeiro PR de código. |
+| 06/04/2026 | n/d           | Sprint 1 ainda não iniciado. Coleta começa a partir do primeiro PR com código de produção. |

--- a/docs/metricas/m1-cobertura-testes.md
+++ b/docs/metricas/m1-cobertura-testes.md
@@ -1,0 +1,21 @@
+# M1: Cobertura de Testes Automatizados
+
+**Classificação:** Produto
+
+**Objetivo:** Garantir que o código está sendo testado de forma adequada.
+
+**Como medir:** percentual de linhas cobertas por testes em relação ao total — (linhas cobertas / total de linhas) × 100.
+
+**Fonte:** relatório de cobertura gerado no CI a cada Pull Request.
+
+**Responsável:** Giuliano
+
+**Interpretação:** a meta mínima é 60%. Abaixo disso, o merge é bloqueado até cobrir o que está faltando.
+
+---
+
+## Histórico de coleta
+
+| Data       | Valor coletado | Observação                        |
+|------------|---------------|-----------------------------------|
+| 06/04/2026 | —             | Sprint 1 ainda não iniciado. Coleta começa após o primeiro PR de código. |

--- a/docs/metricas/m2-taxa-erros-producao.md
+++ b/docs/metricas/m2-taxa-erros-producao.md
@@ -2,15 +2,15 @@
 
 **Classificação:** Produto
 
-**Objetivo:** Monitorar a estabilidade do sistema após cada deploy.
+**Objetivo:** Acompanhar a estabilidade do sistema após cada deploy e identificar regressões rapidamente.
 
 **Como medir:** (erros registrados / total de requisições) × 100.
 
-**Fonte:** logs da aplicação em staging ou produção, atualizado a cada deploy.
+**Fonte:** logs da aplicação em staging ou produção, consultados a cada deploy.
 
 **Responsável:** Giuliano
 
-**Interpretação:** acima de 2% de erros já indica necessidade de hotfix prioritário.
+**Interpretação:** acima de 2% de erros já indica que é necessário abrir um hotfix com prioridade alta.
 
 ---
 
@@ -18,4 +18,4 @@
 
 | Data       | Valor coletado | Observação                        |
 |------------|---------------|-----------------------------------|
-| 06/04/2026 | —             | Ambiente de staging ainda não disponível. Coleta começa no primeiro deploy do Sprint 1. |
+| 06/04/2026 | n/d           | Ambiente de staging ainda não disponível. Coleta começa no primeiro deploy do Sprint 1. |

--- a/docs/metricas/m2-taxa-erros-producao.md
+++ b/docs/metricas/m2-taxa-erros-producao.md
@@ -1,0 +1,21 @@
+# M2: Taxa de Erros em Produção
+
+**Classificação:** Produto
+
+**Objetivo:** Monitorar a estabilidade do sistema após cada deploy.
+
+**Como medir:** (erros registrados / total de requisições) × 100.
+
+**Fonte:** logs da aplicação em staging ou produção, atualizado a cada deploy.
+
+**Responsável:** Giuliano
+
+**Interpretação:** acima de 2% de erros já indica necessidade de hotfix prioritário.
+
+---
+
+## Histórico de coleta
+
+| Data       | Valor coletado | Observação                        |
+|------------|---------------|-----------------------------------|
+| 06/04/2026 | —             | Ambiente de staging ainda não disponível. Coleta começa no primeiro deploy do Sprint 1. |

--- a/docs/metricas/m3-tempo-resposta.md
+++ b/docs/metricas/m3-tempo-resposta.md
@@ -2,15 +2,15 @@
 
 **Classificação:** Produto
 
-**Objetivo:** Verificar se o sistema está dentro do RNF02, que exige resposta abaixo de 2 segundos.
+**Objetivo:** Verificar se o sistema atende ao RNF02, que define resposta máxima de 2 segundos por requisição.
 
-**Como medir:** tempo médio entre requisição e resposta (em ms) por endpoint principal.
+**Como medir:** tempo médio entre o envio da requisição e o recebimento da resposta (em ms), por endpoint principal.
 
-**Fonte:** logs do backend ou ferramenta de monitoramento, atualizado a cada sprint.
+**Fonte:** logs do backend ou ferramenta de monitoramento, consultados a cada sprint.
 
 **Responsável:** Giuliano
 
-**Interpretação:** média acima de 2000 ms sinaliza problema de desempenho a ser investigado.
+**Interpretação:** média acima de 2000 ms é sinal de problema de desempenho e precisa ser investigado antes da próxima entrega.
 
 ---
 
@@ -18,4 +18,4 @@
 
 | Data       | Valor coletado | Observação                        |
 |------------|---------------|-----------------------------------|
-| 06/04/2026 | —             | Nenhum endpoint implementado ainda. Coleta começa após o scaffolding do Sprint 1. |
+| 06/04/2026 | n/d           | Nenhum endpoint implementado ainda. Coleta começa após o scaffolding do Sprint 1. |

--- a/docs/metricas/m3-tempo-resposta.md
+++ b/docs/metricas/m3-tempo-resposta.md
@@ -1,0 +1,21 @@
+# M3: Tempo de Resposta das Requisições
+
+**Classificação:** Produto
+
+**Objetivo:** Verificar se o sistema está dentro do RNF02, que exige resposta abaixo de 2 segundos.
+
+**Como medir:** tempo médio entre requisição e resposta (em ms) por endpoint principal.
+
+**Fonte:** logs do backend ou ferramenta de monitoramento, atualizado a cada sprint.
+
+**Responsável:** Giuliano
+
+**Interpretação:** média acima de 2000 ms sinaliza problema de desempenho a ser investigado.
+
+---
+
+## Histórico de coleta
+
+| Data       | Valor coletado | Observação                        |
+|------------|---------------|-----------------------------------|
+| 06/04/2026 | —             | Nenhum endpoint implementado ainda. Coleta começa após o scaffolding do Sprint 1. |

--- a/docs/metricas/m4-taxa-aprovacao-prs.md
+++ b/docs/metricas/m4-taxa-aprovacao-prs.md
@@ -1,0 +1,21 @@
+# M4: Taxa de Aprovação de Pull Requests
+
+**Classificação:** Processo
+
+**Objetivo:** Avaliar a qualidade do código entregue antes do merge.
+
+**Como medir:** (PRs aprovados sem revisão adicional / total de PRs abertos) × 100.
+
+**Fonte:** GitHub Pull Requests, atualizado a cada sprint.
+
+**Responsável:** Giuliano
+
+**Interpretação:** taxa baixa pode indicar falta de alinhamento entre membros ou DoD mal aplicado.
+
+---
+
+## Histórico de coleta
+
+| Data       | Valor coletado | Observação                        |
+|------------|---------------|-----------------------------------|
+| 06/04/2026 | —             | Sprint 1 ainda não iniciado. Coleta começa ao final do primeiro sprint. |

--- a/docs/metricas/m4-taxa-aprovacao-prs.md
+++ b/docs/metricas/m4-taxa-aprovacao-prs.md
@@ -2,15 +2,15 @@
 
 **Classificação:** Processo
 
-**Objetivo:** Avaliar a qualidade do código entregue antes do merge.
+**Objetivo:** Avaliar a qualidade do código entregue nos PRs antes do merge.
 
 **Como medir:** (PRs aprovados sem revisão adicional / total de PRs abertos) × 100.
 
-**Fonte:** GitHub Pull Requests, atualizado a cada sprint.
+**Fonte:** GitHub Pull Requests, consultados ao final de cada sprint.
 
 **Responsável:** Giuliano
 
-**Interpretação:** taxa baixa pode indicar falta de alinhamento entre membros ou DoD mal aplicado.
+**Interpretação:** taxa baixa pode indicar falta de alinhamento entre os membros ou DoD sendo aplicado de forma inconsistente.
 
 ---
 
@@ -18,4 +18,4 @@
 
 | Data       | Valor coletado | Observação                        |
 |------------|---------------|-----------------------------------|
-| 06/04/2026 | —             | Sprint 1 ainda não iniciado. Coleta começa ao final do primeiro sprint. |
+| 06/04/2026 | n/d           | Sprint 1 ainda não iniciado. Coleta começa ao final do primeiro sprint. |

--- a/docs/metricas/m5-velocity.md
+++ b/docs/metricas/m5-velocity.md
@@ -1,0 +1,25 @@
+# M5: Velocity por Sprint
+
+**Classificação:** Projeto
+
+**Objetivo:** Acompanhar a capacidade real de entrega da equipe sprint a sprint, permitindo comparação com a estimativa de 8 SP/sprint definida no baseline.
+
+**Como medir:** somar os Story Points de todas as issues movidas para "Done" no board do GitHub Projects ao final de cada sprint.
+
+**Fonte:** board do GitHub Projects (projeto Librum), coluna "Done", filtrado por sprint.
+
+**Responsável:** Maria (Scrum Master)
+
+**Interpretação:**
+- Velocity ≥ 8 SP: dentro do planejado.
+- Velocity entre 6–7 SP: desvio leve — revisar impedimentos na retrospectiva.
+- Velocity entre 4–5 SP: desvio moderado — repriorizar backlog conforme plano de contingência.
+- Velocity < 4 SP: desvio crítico — acionar redefinição formal de escopo (ver `baseline.md`).
+
+---
+
+## Histórico de coleta
+
+| Sprint   | Data de coleta | Velocity (SP entregues) | Observação                          |
+|----------|---------------|------------------------|-------------------------------------|
+| Sprint 1 | —             | —                      | Sprint ainda não concluído. Coleta ao final do ciclo. |

--- a/docs/metricas/m5-velocity.md
+++ b/docs/metricas/m5-velocity.md
@@ -2,7 +2,7 @@
 
 **Classificação:** Projeto
 
-**Objetivo:** Acompanhar a capacidade real de entrega da equipe sprint a sprint, permitindo comparação com a estimativa de 8 SP/sprint definida no baseline.
+**Objetivo:** Acompanhar a capacidade real de entrega da equipe sprint a sprint e comparar com a estimativa de 8 SP/sprint definida no baseline.
 
 **Como medir:** somar os Story Points de todas as issues movidas para "Done" no board do GitHub Projects ao final de cada sprint.
 
@@ -11,10 +11,10 @@
 **Responsável:** Maria (Scrum Master)
 
 **Interpretação:**
-- Velocity ≥ 8 SP: dentro do planejado.
-- Velocity entre 6–7 SP: desvio leve — revisar impedimentos na retrospectiva.
-- Velocity entre 4–5 SP: desvio moderado — repriorizar backlog conforme plano de contingência.
-- Velocity < 4 SP: desvio crítico — acionar redefinição formal de escopo (ver `baseline.md`).
+- Velocity maior ou igual a 8 SP: dentro do planejado.
+- Velocity entre 6 e 7 SP: desvio leve, revisar impedimentos na retrospectiva.
+- Velocity entre 4 e 5 SP: desvio moderado, repriorizar o backlog conforme o plano de contingência.
+- Velocity abaixo de 4 SP: desvio crítico, acionar redefinição formal de escopo (ver `baseline.md`).
 
 ---
 
@@ -22,4 +22,4 @@
 
 | Sprint   | Data de coleta | Velocity (SP entregues) | Observação                          |
 |----------|---------------|------------------------|-------------------------------------|
-| Sprint 1 | —             | —                      | Sprint ainda não concluído. Coleta ao final do ciclo. |
+| Sprint 1 | n/d           | n/d                    | Sprint ainda não concluído. Coleta ao final do ciclo. |


### PR DESCRIPTION
## Descricao

Atende ao item 5 da avaliacao da Entrega 3: separacao das fichas de metricas em arquivos individuais dentro de docs/metricas/, com numeracao (M1-M5), historico de coleta em cada ficha e adicao da primeira metrica de projeto (M5 - Velocity por Sprint).

Closes #53 
---

## Tipo de Mudanca

- [ ] Nova funcionalidade
- [ ] Correcao de bug
- [ ] Melhoria de codigo
- [x] Documentacao
- [ ] Testes
- [ ] Configuracao/infraestrutura
---

## Como Testar

1. Verificar que a pasta docs/metricas/ contem os arquivos m1 a m5 e um README.
2. Verificar que cada arquivo tem: numero, classificacao, objetivo, responsavel e tabela de historico de coleta.
3. Verificar que M5 esta classificada como Projeto.
4. Verificar que o README.md do projeto aponta para ./docs/metricas/.
---

## Checklist

- [x] Codigo compila e executa sem erros
- [x] Padroes de codigo seguidos (lint/formatacao)
- [x] Commits seguem Conventional Commits
- [x] Branch atualizada com main