### PR TITLE
feat(auth): implementa backend de autenticação (US-01)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# VS Code
+.vscode/

--- a/backend/src/main/java/com/librum/controller/AuthController.java
+++ b/backend/src/main/java/com/librum/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.librum.controller;
+
+import com.librum.dto.AuthResponse;
+import com.librum.dto.LoginRequest;
+import com.librum.dto.RegisterRequest;
+import com.librum.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+        AuthResponse response = authService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        AuthResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/librum/dto/AuthResponse.java
+++ b/backend/src/main/java/com/librum/dto/AuthResponse.java
@@ -1,0 +1,17 @@
+package com.librum.dto;
+
+import java.util.UUID;
+
+public class AuthResponse {
+
+    private UUID userId;
+    private String token;
+
+    public AuthResponse(UUID userId, String token) {
+        this.userId = userId;
+        this.token = token;
+    }
+
+    public UUID getUserId() { return userId; }
+    public String getToken() { return token; }
+}

--- a/backend/src/main/java/com/librum/dto/LoginRequest.java
+++ b/backend/src/main/java/com/librum/dto/LoginRequest.java
@@ -1,0 +1,19 @@
+package com.librum.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/backend/src/main/java/com/librum/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/librum/dto/RegisterRequest.java
@@ -1,0 +1,26 @@
+package com.librum.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class RegisterRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    @Size(min = 8, max = 128)
+    private String password;
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+}

--- a/backend/src/main/java/com/librum/exception/DuplicateEmailException.java
+++ b/backend/src/main/java/com/librum/exception/DuplicateEmailException.java
@@ -1,0 +1,8 @@
+package com.librum.exception;
+
+public class DuplicateEmailException extends RuntimeException {
+
+    public DuplicateEmailException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/librum/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/librum/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.librum.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DuplicateEmailException.class)
+    public ResponseEntity<Map<String, String>> handleDuplicateEmail(DuplicateEmailException ex) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Map.of("message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<Map<String, String>> handleBadCredentials(BadCredentialsException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("message", "E-mail ou senha incorretos"));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", "Campos obrigatorios invalidos"));
+    }
+}

--- a/backend/src/main/java/com/librum/model/User.java
+++ b/backend/src/main/java/com/librum/model/User.java
@@ -1,0 +1,45 @@
+package com.librum.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(unique = true, nullable = false, length = 255)
+    private String email;
+
+    @Column(nullable = false, length = 255)
+    private String password;
+
+    @Column(nullable = false)
+    private Integer xp = 0;
+
+    @Column(nullable = false)
+    private Integer level = 1;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public UUID getId() { return id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public Integer getXp() { return xp; }
+    public void setXp(Integer xp) { this.xp = xp; }
+    public Integer getLevel() { return level; }
+    public void setLevel(Integer level) { this.level = level; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/backend/src/main/java/com/librum/model/User.java
+++ b/backend/src/main/java/com/librum/model/User.java
@@ -40,6 +40,7 @@ public class User {
     }
 
     public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
     public String getEmail() { return email; }

--- a/backend/src/main/java/com/librum/model/User.java
+++ b/backend/src/main/java/com/librum/model/User.java
@@ -30,6 +30,15 @@ public class User {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt = LocalDateTime.now();
 
+    public User() {}
+
+    public User(UUID id, String name, String email, String password) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
+
     public UUID getId() { return id; }
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }

--- a/backend/src/main/java/com/librum/repository/UserRepository.java
+++ b/backend/src/main/java/com/librum/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.librum.repository;
+
+import com.librum.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/java/com/librum/security/JwtUtil.java
+++ b/backend/src/main/java/com/librum/security/JwtUtil.java
@@ -1,0 +1,74 @@
+package com.librum.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+    private final long expiration;
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiration}") long expiration) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expiration = expiration;
+    }
+
+    /**
+     * Gera um token JWT assinado com HS256 para o e-mail informado.
+     *
+     * @param email subject do token
+     * @return token JWT como String
+     */
+    public String generateToken(String email) {
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + expiration))
+                .signWith(secretKey, Jwts.SIG.HS256)
+                .compact();
+    }
+
+    /**
+     * Valida o token JWT.
+     *
+     * @param token token JWT a validar
+     * @return true se o token for válido e não expirado; false caso contrário
+     */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Extrai o e-mail (subject) do token JWT.
+     *
+     * @param token token JWT válido
+     * @return e-mail contido no subject do token
+     */
+    public String getEmailFromToken(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/backend/src/main/java/com/librum/security/SecurityConfig.java
+++ b/backend/src/main/java/com/librum/security/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.librum.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/register", "/auth/login").permitAll()
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend/src/main/java/com/librum/service/AuthService.java
+++ b/backend/src/main/java/com/librum/service/AuthService.java
@@ -1,0 +1,54 @@
+package com.librum.service;
+
+import com.librum.dto.AuthResponse;
+import com.librum.dto.LoginRequest;
+import com.librum.dto.RegisterRequest;
+import com.librum.exception.DuplicateEmailException;
+import com.librum.model.User;
+import com.librum.repository.UserRepository;
+import com.librum.security.JwtUtil;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
+
+    public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtUtil jwtUtil) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public AuthResponse register(RegisterRequest request) {
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new DuplicateEmailException("Este e-mail ja esta em uso");
+        }
+
+        User user = new User();
+        user.setName(request.getName());
+        user.setEmail(request.getEmail());
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+
+        User saved = userRepository.save(user);
+        String token = jwtUtil.generateToken(saved.getEmail());
+
+        return new AuthResponse(saved.getId(), token);
+    }
+
+    public AuthResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new BadCredentialsException("E-mail ou senha incorretos"));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BadCredentialsException("E-mail ou senha incorretos");
+        }
+
+        String token = jwtUtil.generateToken(user.getEmail());
+        return new AuthResponse(user.getId(), token);
+    }
+}

--- a/backend/src/test/java/com/librum/security/JwtUtilTest.java
+++ b/backend/src/test/java/com/librum/security/JwtUtilTest.java
@@ -1,0 +1,41 @@
+package com.librum.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JwtUtilTest {
+
+    private JwtUtil jwtUtil;
+
+    @BeforeEach
+    void setUp() {
+        // Criando uma chave secreta e tempo de expiração falsos para o teste
+        String secret = "chave-secreta-muito-segura-para-testes-unitarios-123456";
+        long expiration = 3600000; // 1 hora
+        
+        jwtUtil = new JwtUtil(secret, expiration);
+    }
+
+    @Test
+    void gerarToken_emailValido_tokenEhValido() {
+        String email = "teste@librum.com";
+        String token = jwtUtil.generateToken(email);
+
+        boolean isValid = jwtUtil.validateToken(token);
+
+        assertTrue(isValid);
+    }
+
+    @Test
+    void gerarToken_emailValido_emailExtraidoCorretamente() {
+        String email = "teste@librum.com";
+        String token = jwtUtil.generateToken(email);
+
+        String emailExtraido = jwtUtil.getEmailFromToken(token);
+
+        assertEquals("teste@librum.com", emailExtraido);
+    }
+}

--- a/backend/src/test/java/com/librum/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/librum/service/AuthServiceTest.java
@@ -1,0 +1,147 @@
+package com.librum.service;
+
+import com.librum.dto.AuthResponse;
+import com.librum.dto.LoginRequest;
+import com.librum.dto.RegisterRequest;
+import com.librum.exception.DuplicateEmailException;
+import com.librum.model.User;
+import com.librum.repository.UserRepository;
+import com.librum.security.JwtUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = new User();
+        user.setId(UUID.randomUUID());
+        user.setName("Teste");
+        user.setEmail("teste@librum.com");
+        user.setPassword("hash123");
+    }
+
+    @Test
+    void registrar_usuarioValido_retornaTokenJWT() {
+        RegisterRequest request = new RegisterRequest();
+        request.setName("Teste");
+        request.setEmail("teste@librum.com");
+        request.setPassword("senha123");
+
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(request.getPassword())).thenReturn("hash123");
+        when(userRepository.save(any(User.class))).thenReturn(user);
+        when(jwtUtil.generateToken(user.getEmail())).thenReturn("token_jwt");
+
+        AuthResponse response = authService.register(request);
+
+        assertNotNull(response.getToken());
+        assertEquals("token_jwt", response.getToken());
+    }
+
+    @Test
+    void registrar_emailDuplicado_lancaDuplicateEmailException() {
+        RegisterRequest request = new RegisterRequest();
+        request.setEmail("teste@librum.com");
+
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.of(user));
+
+        assertThrows(DuplicateEmailException.class, () -> {
+            authService.register(request);
+        });
+        
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void registrar_senhaArmazenada_comHashBcrypt() {
+        RegisterRequest request = new RegisterRequest();
+        request.setName("Teste");
+        request.setEmail("teste@librum.com");
+        request.setPassword("senha123");
+
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(request.getPassword())).thenReturn("hash-gerado-pelo-bcrypt");
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        authService.register(request);
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+
+        User capturedUser = userCaptor.getValue();
+        assertEquals("hash-gerado-pelo-bcrypt", capturedUser.getPassword());
+    }
+
+    @Test
+    void login_credenciaisCorretas_retornaTokenJWT() {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("teste@librum.com");
+        request.setPassword("senha123");
+
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(true);
+        when(jwtUtil.generateToken(user.getEmail())).thenReturn("token_jwt");
+
+        AuthResponse response = authService.login(request);
+
+        assertNotNull(response.getToken());
+        assertEquals("token_jwt", response.getToken());
+    }
+
+    @Test
+    void login_senhaErrada_lancaBadCredentialsException() {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("teste@librum.com");
+        request.setPassword("senhaErrada");
+
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(request.getPassword(), user.getPassword())).thenReturn(false);
+
+        assertThrows(BadCredentialsException.class, () -> {
+            authService.login(request);
+        });
+    }
+
+    @Test
+    void login_emailInexistente_lancaBadCredentialsException() {
+        LoginRequest request = new LoginRequest();
+        request.setEmail("naoexiste@librum.com");
+        request.setPassword("senha123");
+
+        when(userRepository.findByEmail(request.getEmail())).thenReturn(Optional.empty());
+
+        assertThrows(BadCredentialsException.class, () -> {
+            authService.login(request);
+        });
+    }
+}


### PR DESCRIPTION
## Descrição
> Implementa o backend completo de autenticação da US01: entidade User, repositório
> JPA, SecurityConfig, JwtUtil, DTOs, AuthService, AuthController e tratamento
> global de erros. Inclui 8 testes de unidade automatizados cobrindo os casos
> principais de registro e login.

Closes #42 Closes #44 Closes #36 Closes #41 Closes #43 

---
## Tipo de Mudança
- [X] Nova funcionalidade
- [ ] Correção de bug
- [ ] Melhoria de código
- [ ] Documentação
- [X] Testes
- [ ] Configuração/infraestrutura

---
## Como Testar
1. Iniciar o banco com `docker-compose up -d`.
2. Rodar `./mvnw spring-boot:run` na pasta `backend/`.
3. Rodar `./mvnw test` e confirmar que todos os 8 testes passam.
4. Testar os endpoints manualmente:
   - `POST localhost:8080/auth/register` → `{ "name": "Teste", "email": "teste@librum.com", "password": "senha1234" }` → esperado: 201 com token
   - `POST localhost:8080/auth/login` com as mesmas credenciais → esperado: 200 com token
   - Repetir o register com o mesmo e-mail → esperado: 409
   - Login com senha errada → esperado: 401

**Resultado esperado:**
8 testes passando. Endpoints respondendo conforme `docs/contrato-api-auth.md`.

---
## Checklist
- [X] Código compila e executa sem erros
- [X] Testes adicionados/atualizados e passando
- [X] Padrões de código seguidos (lint/formatação)
- [X] Commits seguem Conventional Commits
- [X] Branch atualizada com `main`