### PR TITLE
ci: adiciona workflow GitHub Actions com testes do backend e build do…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI - Testes automatizados
+
+on:
+  push:
+    branches: [ main, 'feat/**', 'ci/**' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: librum_test
+          POSTGRES_USER: librum
+          POSTGRES_PASSWORD: librum
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configurar Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+      - name: Rodar testes do backend
+        working-directory: ./backend
+        run: ./mvnw test
+        env:
+          DATABASE_URL: jdbc:postgresql://localhost:5432/librum_test
+          JWT_SECRET: ci-secret-key-somente-para-testes
+
+  frontend-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configurar Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Instalar dependências
+        working-directory: ./frontend
+        run: npm ci
+      - name: Verificar build
+        working-directory: ./frontend
+        run: npm run build


### PR DESCRIPTION
## Descrição
Configura o pipeline de CI com GitHub Actions para rodar automaticamente os testes de unidade do backend e o build do frontend a cada push e PR. A partir deste PR, nenhum merge em `main` poderá ser feito enquanto o CI estiver vermelho.

Closes #46 

---
## Tipo de Mudança
- [ ] Nova funcionalidade
- [ ] Correção de bug
- [ ] Melhoria de código
- [ ] Documentação
- [ ] Testes
- [X] Configuração/infraestrutura

---
## Como Testar
1. Abrir qualquer PR para `main` e verificar que os checks de CI aparecem automaticamente na aba de checks do PR.
2. Na aba "Actions", confirmar que o workflow `CI - Testes automatizados` aparece e roda.
3. Verificar que o job `backend-tests` executa `./mvnw test` com todos os testes passando.
4. Verificar que o job `frontend-build` executa `npm run build` sem erros.

**Resultado esperado:**
Workflow verde na aba Actions após o merge.

---
## Checklist
- [X] Código compila e executa sem erros
- [X] Testes adicionados/atualizados e passando
- [X] Padrões de código seguidos (lint/formatação)
- [X] Commits seguem Conventional Commits
- [X] Branch atualizada com `main`