### PR TITLE
Feat/sprint2 contratos

### DIFF
--- a/docs/adrs/ADR-0006-modelagem-conteudo-leitura.md
+++ b/docs/adrs/ADR-0006-modelagem-conteudo-leitura.md
@@ -1,0 +1,26 @@
+# ADR-0006 - Modelagem do conteúdo literário e rastreamento de progresso
+
+## Contexto
+
+Precisávamos decidir como organizar livros, fases e trechos de texto no banco, e como registrar o progresso de cada usuário por fase, de forma que o sistema consiga determinar quais fases estão desbloqueadas.
+
+## Decisão
+
+Cinco tabelas relacionadas: `genres`, `books`, `phases`, `phase_segments` e `user_progress`.
+
+- `genres`: armazena os gêneros literários disponíveis (Aventura, Terror, etc.).
+- `books`: cada livro pertence a um gênero. Nesta sprint, há somente um livro por gênero.
+- `phases`: cada fase pertence a um livro e tem um número de ordem.
+- `phase_segments`: cada segmento de texto pertence a uma fase e tem um número de ordem. O campo `content` armazena o trecho literário.
+- `user_progress`: registra, por par (usuário, fase), o último segmento lido e se a fase foi concluída.
+
+A regra de desbloqueio é: a Fase N fica desbloqueada quando `user_progress.is_completed = true` para a Fase N-1 do mesmo livro. A Fase 1 está sempre desbloqueada.
+
+## Alternativas consideradas
+
+- Campo JSON de progresso na tabela `users`: descartado porque dificulta queries de desbloqueio e não permite registrar progresso por fase de forma independente.
+- Tabela única de conteúdo sem divisão em fases: descartado porque não suporta desbloqueio progressivo nem a navegação trecho a trecho exigida pelo wireframe.
+
+## O que isso implica
+
+O `ReadingService` consulta `user_progress` para verificar se uma fase está desbloqueada antes de entregar o conteúdo. Se não houver registro para aquela (usuário, fase), a fase não foi iniciada e o desbloqueio é determinado somente pela conclusão da fase anterior. A constraint `UNIQUE(user_id, phase_id)` garante que há no máximo um registro de progresso por par.

--- a/docs/adrs/ADR-0007-facade-reading-service.md
+++ b/docs/adrs/ADR-0007-facade-reading-service.md
@@ -1,0 +1,24 @@
+# ADR-0007 - Uso do padrão Facade no ReadingService
+
+## Contexto
+
+O controller de leitura precisaria acessar quatro repositories diferentes para montar a resposta de um único segmento: `PhaseRepository` (verificar se a fase existe), `UserProgressRepository` (verificar se está desbloqueada), `PhaseSegmentRepository` (buscar o conteúdo) e `BookRepository` (buscar título e autor). Colocar essa lógica diretamente no controller violaria a separação de responsabilidades e dificultaria os testes.
+
+## Decisão
+
+`ReadingService.java` implementa o padrão Facade: é o único ponto de entrada para toda a lógica de leitura. O controller chama apenas dois métodos: `getPhaseSegment` e `getPhasesForGenre`. Internamente, o service coordena os quatro repositories.
+
+## Alternativas consideradas
+
+- Controller acessando os repositories diretamente: descartado porque espalha lógica de negócio no controller e torna o teste do controller dependente de quatro mocks.
+- DTO assembler separado: descartado porque adicionaria uma camada extra sem benefício claro dentro do escopo desta sprint.
+
+## Classes afetadas
+
+- `ReadingService` (implementa a Facade)
+- `ReadingController` (consume a Facade)
+- `PhaseRepository`, `PhaseSegmentRepository`, `UserProgressRepository`, `BookRepository` (internos à Facade)
+
+## O que isso implica
+
+O controller fica simples e testável: depende de um único collaborator. A lógica de desbloqueio, busca de conteúdo e montagem do DTO ficam centralizadas em `ReadingService`. O trade-off é que `ReadingService` tende a crescer em responsabilidade conforme novas funcionalidades de leitura forem adicionadas nas próximas sprints.

--- a/docs/contrato-api-leitura.md
+++ b/docs/contrato-api-leitura.md
@@ -1,0 +1,143 @@
+# Contrato de API — Leitura e Progresso
+
+Endpoints implementados na Sprint 2 para as US04 e US05.
+
+URL base: `http://localhost:8080`
+
+---
+
+## GET /genres
+
+Lista todos os gêneros literários disponíveis.
+
+**Autenticação:** não exigida (endpoint público).
+
+**Resposta 200:**
+
+```json
+[
+  {
+    "id": 1,
+    "name": "Aventura",
+    "slug": "aventura",
+    "iconEmoji": "⚔️",
+    "description": "Histórias de exploração e descoberta."
+  }
+]
+```
+
+---
+
+## GET /genres/{genreId}/phases
+
+Lista as fases do livro disponível para um gênero, com o status de desbloqueio do usuário autenticado.
+
+**Autenticação:** `Authorization: Bearer <token>` (obrigatório).
+
+**Parâmetros de rota:**
+
+- `genreId` (Long): identificador do gênero.
+
+**Resposta 200:**
+
+```json
+[
+  {
+    "id": 1,
+    "phaseNumber": 1,
+    "title": "Fase 1: O Início da Aventura",
+    "bookTitle": "A Ilha do Tesouro",
+    "bookAuthor": "Robert Louis Stevenson",
+    "totalSegments": 4,
+    "isUnlocked": true,
+    "isCompleted": false
+  },
+  {
+    "id": 2,
+    "phaseNumber": 2,
+    "title": "Fase 2: O Mapa Secreto",
+    "bookTitle": "A Ilha do Tesouro",
+    "bookAuthor": "Robert Louis Stevenson",
+    "totalSegments": 3,
+    "isUnlocked": false,
+    "isCompleted": false
+  }
+]
+```
+
+- `isUnlocked`: `true` para a Fase 1 sempre; `true` para a Fase N se a Fase N-1 está com `isCompleted = true`.
+- `isCompleted`: `true` se o usuário leu todos os segmentos da fase.
+
+**Resposta 401:** token ausente ou inválido.
+
+---
+
+## GET /reading/{phaseId}/{segmentNumber}
+
+Retorna o conteúdo de um segmento de texto de uma fase.
+
+**Autenticação:** `Authorization: Bearer <token>` (obrigatório).
+
+**Parâmetros de rota:**
+
+- `phaseId` (Long): identificador da fase.
+- `segmentNumber` (int): número do trecho, começando em 1.
+
+**Resposta 200:**
+
+```json
+{
+  "segmentNumber": 1,
+  "totalSegments": 4,
+  "content": "Era uma noite de outubro, fria e com vento...",
+  "estimatedMinutes": 3,
+  "phaseTitle": "Fase 1: O Início da Aventura",
+  "phaseNumber": 1,
+  "bookTitle": "A Ilha do Tesouro",
+  "bookAuthor": "Robert Louis Stevenson",
+  "genreName": "Aventura"
+}
+```
+
+**Resposta 401:** token ausente ou inválido.
+
+**Resposta 403:** fase bloqueada para o usuário (fase anterior não concluída).
+
+**Resposta 404:** segmento não existe na fase.
+
+---
+
+## POST /progress/mark-read
+
+Registra que o usuário leu um segmento. Se for o último segmento da fase, marca a fase como concluída e desbloqueia a fase seguinte.
+
+**Autenticação:** `Authorization: Bearer <token>` (obrigatório).
+
+**Corpo da requisição:**
+
+```json
+{
+  "phaseId": 1,
+  "segmentNumber": 2
+}
+```
+
+- `phaseId`: obrigatório.
+- `segmentNumber`: obrigatório.
+
+**Resposta 200:**
+
+```json
+{
+  "lastSegmentRead": 2,
+  "phaseCompleted": false,
+  "nextPhaseUnlocked": false
+}
+```
+
+- `phaseCompleted`: `true` quando `segmentNumber` é o último da fase.
+- `nextPhaseUnlocked`: `true` quando a fase foi concluída agora (ou seja, a próxima acabou de ser desbloqueada).
+
+**Resposta 400:** campos ausentes ou inválidos.
+
+**Resposta 401:** token ausente ou inválido.


### PR DESCRIPTION
## Descrição

> Define o contrato de API para os 4 endpoints de leitura e progresso
> (GET /genres, GET /genres/{id}/phases, GET /reading/{phaseId}/{segmentNumber},
> POST /progress/mark-read) e registra as decisões arquiteturais de modelagem
> de conteúdo literário (ADR-0006) e de uso do padrão Facade no ReadingService
> (ADR-0007). Estes artefatos são pré-requisito para o desenvolvimento paralelo
> de frontend e backend sem risco de desalinhamento de contrato.

Closes #58 

---

## Tipo de Mudança

- [ ] Nova funcionalidade
- [ ] Correção de bug
- [ ] Melhoria de código
- [x] Documentação
- [ ] Testes
- [ ] Configuração/infraestrutura

---

## Como Testar

1. Abrir `docs/contrato-api-leitura.md` e verificar que os 4 endpoints estão documentados com método, rota, autenticação, body e códigos de resposta.
2. Abrir `docs/adrs/ADR-0006-modelagem-conteudo-leitura.md` e confirmar que segue o formato dos ADRs existentes (contexto, decisão, alternativas, implicações).
3. Abrir `docs/adrs/ADR-0007-facade-reading-service.md` e confirmar o mesmo formato.

**Resultado esperado:** contrato e ADRs presentes, revisados e mergeados antes do início do desenvolvimento de backend e frontend de leitura.

---

## Checklist

- [ ] Código compila e executa sem erros
- [ ] Testes adicionados/atualizados e passando
- [ ] Padrões de código seguidos (lint/formatação)
- [ ] Commits seguem Conventional Commits
- [ ] Branch atualizada com `main`