### PR TITLE
Feat/us04 us05 backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -87,6 +87,13 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Spring Security Test (fornece @WithMockUser e SecurityMockMvcRequestPostProcessors) -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/librum/controller/ProgressController.java
+++ b/backend/src/main/java/com/librum/controller/ProgressController.java
@@ -1,0 +1,41 @@
+package com.librum.controller;
+
+import com.librum.dto.ProgressRequest;
+import com.librum.repository.UserRepository;
+import com.librum.model.User;
+import com.librum.service.ProgressService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/progress")
+public class ProgressController {
+
+    private final ProgressService progressService;
+    private final UserRepository userRepository;
+
+    public ProgressController(ProgressService progressService, UserRepository userRepository) {
+        this.progressService = progressService;
+        this.userRepository = userRepository;
+    }
+
+    @PostMapping("/mark-read")
+    public ResponseEntity<Map<String, Object>> markRead(
+            @Valid @RequestBody ProgressRequest request,
+            @AuthenticationPrincipal String email) {
+        UUID userId = userRepository.findByEmail(email)
+                .map(User::getId)
+                .orElseThrow();
+        Map<String, Object> result = progressService.markSegmentRead(
+                userId, request.getPhaseId(), request.getSegmentNumber());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/src/main/java/com/librum/controller/ReadingController.java
+++ b/backend/src/main/java/com/librum/controller/ReadingController.java
@@ -1,0 +1,62 @@
+package com.librum.controller;
+
+import com.librum.dto.GenreResponse;
+import com.librum.dto.PhaseReadingResponse;
+import com.librum.dto.PhaseSegmentResponse;
+import com.librum.model.User;
+import com.librum.repository.GenreRepository;
+import com.librum.repository.UserRepository;
+import com.librum.service.ReadingService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+public class ReadingController {
+
+    private final ReadingService readingService;
+    private final GenreRepository genreRepository;
+    private final UserRepository userRepository;
+
+    public ReadingController(ReadingService readingService,
+                             GenreRepository genreRepository,
+                             UserRepository userRepository) {
+        this.readingService = readingService;
+        this.genreRepository = genreRepository;
+        this.userRepository = userRepository;
+    }
+
+    @GetMapping("/genres")
+    public ResponseEntity<List<GenreResponse>> listGenres() {
+        List<GenreResponse> genres = genreRepository.findAll().stream()
+                .map(g -> new GenreResponse(g.getId(), g.getName(), g.getSlug(), g.getIconEmoji(), g.getDescription()))
+                .toList();
+        return ResponseEntity.ok(genres);
+    }
+
+    @GetMapping("/genres/{genreId}/phases")
+    public ResponseEntity<List<PhaseReadingResponse>> listPhases(
+            @PathVariable Long genreId,
+            @AuthenticationPrincipal String email) {
+        UUID userId = getUserId(email);
+        return ResponseEntity.ok(readingService.getPhasesForGenre(userId, genreId));
+    }
+
+    @GetMapping("/reading/{phaseId}/{segmentNumber}")
+    public ResponseEntity<PhaseSegmentResponse> getSegment(
+            @PathVariable Long phaseId,
+            @PathVariable int segmentNumber,
+            @AuthenticationPrincipal String email) {
+        UUID userId = getUserId(email);
+        return ResponseEntity.ok(readingService.getPhaseSegment(userId, phaseId, segmentNumber));
+    }
+
+    private UUID getUserId(String email) {
+        return userRepository.findByEmail(email)
+                .map(User::getId)
+                .orElseThrow();
+    }
+}

--- a/backend/src/main/java/com/librum/dto/GenreResponse.java
+++ b/backend/src/main/java/com/librum/dto/GenreResponse.java
@@ -1,0 +1,9 @@
+package com.librum.dto;
+
+public record GenreResponse(
+        Long id,
+        String name,
+        String slug,
+        String iconEmoji,
+        String description
+) {}

--- a/backend/src/main/java/com/librum/dto/PhaseReadingResponse.java
+++ b/backend/src/main/java/com/librum/dto/PhaseReadingResponse.java
@@ -1,0 +1,12 @@
+package com.librum.dto;
+
+public record PhaseReadingResponse(
+        Long id,
+        int phaseNumber,
+        String title,
+        String bookTitle,
+        String bookAuthor,
+        int totalSegments,
+        boolean isUnlocked,
+        boolean isCompleted
+) {}

--- a/backend/src/main/java/com/librum/dto/PhaseSegmentResponse.java
+++ b/backend/src/main/java/com/librum/dto/PhaseSegmentResponse.java
@@ -1,0 +1,13 @@
+package com.librum.dto;
+
+public record PhaseSegmentResponse(
+        int segmentNumber,
+        int totalSegments,
+        String content,
+        int estimatedMinutes,
+        String phaseTitle,
+        int phaseNumber,
+        String bookTitle,
+        String bookAuthor,
+        String genreName
+) {}

--- a/backend/src/main/java/com/librum/dto/ProgressRequest.java
+++ b/backend/src/main/java/com/librum/dto/ProgressRequest.java
@@ -1,0 +1,17 @@
+package com.librum.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public class ProgressRequest {
+
+    @NotNull
+    private Long phaseId;
+
+    @NotNull
+    private Integer segmentNumber;
+
+    public Long getPhaseId() { return phaseId; }
+    public void setPhaseId(Long phaseId) { this.phaseId = phaseId; }
+    public Integer getSegmentNumber() { return segmentNumber; }
+    public void setSegmentNumber(Integer segmentNumber) { this.segmentNumber = segmentNumber; }
+}

--- a/backend/src/main/java/com/librum/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/librum/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.librum.exception;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -28,5 +29,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(Map.of("message", "Campos obrigatorios invalidos"));
+    }
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNotFound(EntityNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(Map.of("message", ex.getMessage()));
     }
 }

--- a/backend/src/main/java/com/librum/model/Book.java
+++ b/backend/src/main/java/com/librum/model/Book.java
@@ -1,0 +1,27 @@
+package com.librum.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "books")
+public class Book {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "genre_id", nullable = false)
+    private Genre genre;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(nullable = false, length = 150)
+    private String author;
+
+    public Long getId() { return id; }
+    public Genre getGenre() { return genre; }
+    public String getTitle() { return title; }
+    public String getAuthor() { return author; }
+}

--- a/backend/src/main/java/com/librum/model/Genre.java
+++ b/backend/src/main/java/com/librum/model/Genre.java
@@ -1,0 +1,30 @@
+package com.librum.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "genres")
+public class Genre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(unique = true, nullable = false, length = 50)
+    private String slug;
+
+    @Column(name = "icon_emoji", length = 10)
+    private String iconEmoji;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    public Long getId() { return id; }
+    public String getName() { return name; }
+    public String getSlug() { return slug; }
+    public String getIconEmoji() { return iconEmoji; }
+    public String getDescription() { return description; }
+}

--- a/backend/src/main/java/com/librum/model/Phase.java
+++ b/backend/src/main/java/com/librum/model/Phase.java
@@ -1,0 +1,33 @@
+package com.librum.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "phases")
+public class Phase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @Column(name = "phase_number", nullable = false)
+    private int phaseNumber;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    public Phase() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Book getBook() { return book; }
+    public void setBook(Book book) { this.book = book; }
+    public int getPhaseNumber() { return phaseNumber; }
+    public void setPhaseNumber(int phaseNumber) { this.phaseNumber = phaseNumber; }
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+}

--- a/backend/src/main/java/com/librum/model/PhaseSegment.java
+++ b/backend/src/main/java/com/librum/model/PhaseSegment.java
@@ -1,0 +1,38 @@
+package com.librum.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "phase_segments")
+public class PhaseSegment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "phase_id", nullable = false)
+    private Phase phase;
+
+    @Column(name = "segment_number", nullable = false)
+    private int segmentNumber;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "estimated_minutes", nullable = false)
+    private int estimatedMinutes;
+
+    public PhaseSegment() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Phase getPhase() { return phase; }
+    public void setPhase(Phase phase) { this.phase = phase; }
+    public int getSegmentNumber() { return segmentNumber; }
+    public void setSegmentNumber(int segmentNumber) { this.segmentNumber = segmentNumber; }
+    public String getContent() { return content; }
+    public void setContent(String content) { this.content = content; }
+    public int getEstimatedMinutes() { return estimatedMinutes; }
+    public void setEstimatedMinutes(int estimatedMinutes) { this.estimatedMinutes = estimatedMinutes; }
+}

--- a/backend/src/main/java/com/librum/model/UserProgress.java
+++ b/backend/src/main/java/com/librum/model/UserProgress.java
@@ -1,0 +1,47 @@
+package com.librum.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_progress", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"user_id", "phase_id"})
+})
+public class UserProgress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "phase_id", nullable = false)
+    private Phase phase;
+
+    @Column(name = "last_segment_read", nullable = false)
+    private int lastSegmentRead = 0;
+
+    @Column(name = "is_completed", nullable = false)
+    private boolean isCompleted = false;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    public UserProgress() {}
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public Phase getPhase() { return phase; }
+    public void setPhase(Phase phase) { this.phase = phase; }
+    public int getLastSegmentRead() { return lastSegmentRead; }
+    public void setLastSegmentRead(int lastSegmentRead) { this.lastSegmentRead = lastSegmentRead; }
+    public boolean isCompleted() { return isCompleted; }
+    public void setCompleted(boolean completed) { isCompleted = completed; }
+    public LocalDateTime getCompletedAt() { return completedAt; }
+    public void setCompletedAt(LocalDateTime completedAt) { this.completedAt = completedAt; }
+}

--- a/backend/src/main/java/com/librum/repository/BookRepository.java
+++ b/backend/src/main/java/com/librum/repository/BookRepository.java
@@ -1,0 +1,9 @@
+package com.librum.repository;
+
+import com.librum.model.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+    Optional<Book> findByGenreId(Long genreId);
+}

--- a/backend/src/main/java/com/librum/repository/GenreRepository.java
+++ b/backend/src/main/java/com/librum/repository/GenreRepository.java
@@ -1,0 +1,9 @@
+package com.librum.repository;
+
+import com.librum.model.Genre;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface GenreRepository extends JpaRepository<Genre, Long> {
+    Optional<Genre> findBySlug(String slug);
+}

--- a/backend/src/main/java/com/librum/repository/PhaseRepository.java
+++ b/backend/src/main/java/com/librum/repository/PhaseRepository.java
@@ -1,0 +1,10 @@
+package com.librum.repository;
+
+import com.librum.model.Phase;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PhaseRepository extends JpaRepository<Phase, Long> {
+    List<Phase> findByBookIdOrderByPhaseNumber(Long bookId);
+}

--- a/backend/src/main/java/com/librum/repository/PhaseSegmentRepository.java
+++ b/backend/src/main/java/com/librum/repository/PhaseSegmentRepository.java
@@ -1,0 +1,11 @@
+package com.librum.repository;
+
+import com.librum.model.PhaseSegment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PhaseSegmentRepository extends JpaRepository<PhaseSegment, Long> {
+    Optional<PhaseSegment> findByPhaseIdAndSegmentNumber(Long phaseId, int segmentNumber);
+    int countByPhaseId(Long phaseId);
+}

--- a/backend/src/main/java/com/librum/repository/UserProgressRepository.java
+++ b/backend/src/main/java/com/librum/repository/UserProgressRepository.java
@@ -1,0 +1,12 @@
+package com.librum.repository;
+
+import com.librum.model.UserProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserProgressRepository extends JpaRepository<UserProgress, Long> {
+    Optional<UserProgress> findByUserIdAndPhaseId(UUID userId, Long phaseId);
+    boolean existsByUserIdAndPhaseIdAndIsCompletedTrue(UUID userId, Long phaseId);
+}

--- a/backend/src/main/java/com/librum/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/librum/security/JwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package com.librum.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            if (jwtUtil.validateToken(token)) {
+                String email = jwtUtil.getEmailFromToken(token);
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(email, null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/librum/security/SecurityConfig.java
+++ b/backend/src/main/java/com/librum/security/SecurityConfig.java
@@ -2,12 +2,14 @@ package com.librum.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -18,6 +20,12 @@ import java.util.List;
 @EnableWebSecurity
 public class SecurityConfig {
 
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -27,8 +35,10 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/register", "/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/genres").permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/backend/src/main/java/com/librum/service/ProgressService.java
+++ b/backend/src/main/java/com/librum/service/ProgressService.java
@@ -1,0 +1,71 @@
+package com.librum.service;
+
+import com.librum.model.Phase;
+import com.librum.model.User;
+import com.librum.model.UserProgress;
+import com.librum.repository.PhaseRepository;
+import com.librum.repository.PhaseSegmentRepository;
+import com.librum.repository.UserProgressRepository;
+import com.librum.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+public class ProgressService {
+
+    private final UserProgressRepository userProgressRepository;
+    private final PhaseRepository phaseRepository;
+    private final PhaseSegmentRepository phaseSegmentRepository;
+    private final UserRepository userRepository;
+
+    public ProgressService(UserProgressRepository userProgressRepository,
+                           PhaseRepository phaseRepository,
+                           PhaseSegmentRepository phaseSegmentRepository,
+                           UserRepository userRepository) {
+        this.userProgressRepository = userProgressRepository;
+        this.phaseRepository = phaseRepository;
+        this.phaseSegmentRepository = phaseSegmentRepository;
+        this.userRepository = userRepository;
+    }
+
+    public Map<String, Object> markSegmentRead(UUID userId, Long phaseId, int segmentNumber) {
+        Phase phase = phaseRepository.findById(phaseId)
+                .orElseThrow(() -> new EntityNotFoundException("Fase nao encontrada"));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Usuario nao encontrado"));
+
+        UserProgress progress = userProgressRepository
+                .findByUserIdAndPhaseId(userId, phaseId)
+                .orElseGet(() -> {
+                    UserProgress p = new UserProgress();
+                    p.setUser(user);
+                    p.setPhase(phase);
+                    return p;
+                });
+
+        progress.setLastSegmentRead(Math.max(progress.getLastSegmentRead(), segmentNumber));
+
+        int totalSegments = phaseSegmentRepository.countByPhaseId(phaseId);
+        boolean phaseCompleted = segmentNumber == totalSegments;
+
+        if (phaseCompleted && !progress.isCompleted()) {
+            progress.setCompleted(true);
+            progress.setCompletedAt(LocalDateTime.now());
+        }
+
+        userProgressRepository.save(progress);
+
+        boolean nextPhaseUnlocked = phaseCompleted;
+
+        return Map.of(
+                "lastSegmentRead", progress.getLastSegmentRead(),
+                "phaseCompleted", progress.isCompleted(),
+                "nextPhaseUnlocked", nextPhaseUnlocked
+        );
+    }
+}

--- a/backend/src/main/java/com/librum/service/ReadingService.java
+++ b/backend/src/main/java/com/librum/service/ReadingService.java
@@ -1,0 +1,107 @@
+package com.librum.service;
+
+import com.librum.dto.PhaseReadingResponse;
+import com.librum.dto.PhaseSegmentResponse;
+import com.librum.model.Book;
+import com.librum.model.Phase;
+import com.librum.model.PhaseSegment;
+import com.librum.repository.BookRepository;
+import com.librum.repository.PhaseRepository;
+import com.librum.repository.PhaseSegmentRepository;
+import com.librum.repository.UserProgressRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ReadingService {
+
+    private final BookRepository bookRepository;
+    private final PhaseRepository phaseRepository;
+    private final PhaseSegmentRepository phaseSegmentRepository;
+    private final UserProgressRepository userProgressRepository;
+
+    public ReadingService(BookRepository bookRepository,
+                          PhaseRepository phaseRepository,
+                          PhaseSegmentRepository phaseSegmentRepository,
+                          UserProgressRepository userProgressRepository) {
+        this.bookRepository = bookRepository;
+        this.phaseRepository = phaseRepository;
+        this.phaseSegmentRepository = phaseSegmentRepository;
+        this.userProgressRepository = userProgressRepository;
+    }
+
+    public PhaseSegmentResponse getPhaseSegment(UUID userId, Long phaseId, int segmentNumber) {
+        Phase phase = phaseRepository.findById(phaseId)
+                .orElseThrow(() -> new EntityNotFoundException("Fase nao encontrada"));
+
+        if (!isPhaseUnlocked(userId, phase)) {
+            throw new AccessDeniedException("Fase bloqueada para este usuario");
+        }
+
+        PhaseSegment segment = phaseSegmentRepository
+                .findByPhaseIdAndSegmentNumber(phaseId, segmentNumber)
+                .orElseThrow(() -> new EntityNotFoundException("Segmento nao encontrado"));
+
+        int totalSegments = phaseSegmentRepository.countByPhaseId(phaseId);
+        Book book = phase.getBook();
+
+        return new PhaseSegmentResponse(
+                segment.getSegmentNumber(),
+                totalSegments,
+                segment.getContent(),
+                segment.getEstimatedMinutes(),
+                phase.getTitle(),
+                phase.getPhaseNumber(),
+                book.getTitle(),
+                book.getAuthor(),
+                book.getGenre().getName()
+        );
+    }
+
+    public List<PhaseReadingResponse> getPhasesForGenre(UUID userId, Long genreId) {
+        Book book = bookRepository.findByGenreId(genreId)
+                .orElseThrow(() -> new EntityNotFoundException("Livro nao encontrado para este genero"));
+
+        List<Phase> phases = phaseRepository.findByBookIdOrderByPhaseNumber(book.getId());
+
+        return phases.stream().map(phase -> {
+            boolean unlocked = isPhaseUnlocked(userId, phase);
+            boolean completed = userProgressRepository
+                    .existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, phase.getId());
+            int totalSegments = phaseSegmentRepository.countByPhaseId(phase.getId());
+
+            return new PhaseReadingResponse(
+                    phase.getId(),
+                    phase.getPhaseNumber(),
+                    phase.getTitle(),
+                    book.getTitle(),
+                    book.getAuthor(),
+                    totalSegments,
+                    unlocked,
+                    completed
+            );
+        }).toList();
+    }
+
+    private boolean isPhaseUnlocked(UUID userId, Phase phase) {
+        if (phase.getPhaseNumber() == 1) {
+            return true;
+        }
+
+        List<Phase> phases = phaseRepository.findByBookIdOrderByPhaseNumber(phase.getBook().getId());
+        Phase previousPhase = phases.stream()
+                .filter(p -> p.getPhaseNumber() == phase.getPhaseNumber() - 1)
+                .findFirst()
+                .orElse(null);
+
+        if (previousPhase == null) {
+            return false;
+        }
+
+        return userProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, previousPhase.getId());
+    }
+}

--- a/backend/src/main/resources/db/migration/V2__reading_schema.sql
+++ b/backend/src/main/resources/db/migration/V2__reading_schema.sql
@@ -1,0 +1,39 @@
+CREATE TABLE genres (
+    id          BIGSERIAL PRIMARY KEY,
+    name        VARCHAR(100) NOT NULL,
+    slug        VARCHAR(50)  UNIQUE NOT NULL,
+    icon_emoji  VARCHAR(10),
+    description TEXT
+);
+
+CREATE TABLE books (
+    id          BIGSERIAL PRIMARY KEY,
+    genre_id    BIGINT NOT NULL REFERENCES genres(id),
+    title       VARCHAR(200) NOT NULL,
+    author      VARCHAR(150) NOT NULL
+);
+
+CREATE TABLE phases (
+    id           BIGSERIAL PRIMARY KEY,
+    book_id      BIGINT NOT NULL REFERENCES books(id),
+    phase_number INT    NOT NULL,
+    title        VARCHAR(200) NOT NULL
+);
+
+CREATE TABLE phase_segments (
+    id               BIGSERIAL PRIMARY KEY,
+    phase_id         BIGINT NOT NULL REFERENCES phases(id),
+    segment_number   INT    NOT NULL,
+    content          TEXT   NOT NULL,
+    estimated_minutes INT   NOT NULL DEFAULT 3
+);
+
+CREATE TABLE user_progress (
+    id                BIGSERIAL PRIMARY KEY,
+    user_id           UUID   NOT NULL REFERENCES users(id),
+    phase_id          BIGINT NOT NULL REFERENCES phases(id),
+    last_segment_read INT    NOT NULL DEFAULT 0,
+    is_completed      BOOLEAN NOT NULL DEFAULT FALSE,
+    completed_at      TIMESTAMP,
+    UNIQUE(user_id, phase_id)
+);

--- a/backend/src/main/resources/db/migration/V3__seed_initial_content.sql
+++ b/backend/src/main/resources/db/migration/V3__seed_initial_content.sql
@@ -1,0 +1,163 @@
+INSERT INTO genres (name, slug, icon_emoji, description) VALUES
+  ('Aventura', 'aventura', 'Histórias de ação, exploração e coragem'),
+  ('Terror', 'terror', 'Narrativas de suspense e medo'),
+  ('Romance', 'romance', 'Histórias de amor e relacionamentos'),
+  ('Fantasia', 'fantasia', 'Mundos mágicos e criaturas fantásticas'),
+  ('Suspense', 'suspense', 'Mistérios e reviravoltas inesperadas');
+
+INSERT INTO books (genre_id, title, author)
+SELECT id, 'A Ilha do Tesouro', 'Robert Louis Stevenson'
+FROM genres WHERE slug = 'aventura';
+
+INSERT INTO phases (book_id, phase_number, title)
+SELECT id, 1, 'Fase 1: O Início da Aventura' FROM books WHERE title = 'A Ilha do Tesouro';
+INSERT INTO phases (book_id, phase_number, title)
+SELECT id, 2, 'Fase 2: A Bordo do Hispaniola' FROM books WHERE title = 'A Ilha do Tesouro';
+INSERT INTO phases (book_id, phase_number, title)
+SELECT id, 3, 'Fase 3: Segredos da Ilha' FROM books WHERE title = 'A Ilha do Tesouro';
+INSERT INTO phases (book_id, phase_number, title)
+SELECT id, 4, 'Fase 4: O Tesouro do Capitão Flint' FROM books WHERE title = 'A Ilha do Tesouro';
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 1,
+'O velho marinheiro chegou numa tarde fria de outono, carregando um baú enorme nas costas. Ele era um homem alto, forte, com as mãos calejadas e um corte profundo na bochecha esquerda. Pediu um quarto e ficou olhando para o mar por horas.
+
+Meu pai disse que era um hóspede difícil, mas que pagava bem. O homem bebia rum todas as noites e cantava velhas canções de marinheiro, batendo o punho na mesa quando chegava ao refrão.
+
+Ele me chamou de lado no segundo dia e me ofereceu uma moeda de prata por mês se eu ficasse de olho em um marinheiro de uma perna só. Eu não sabia o que pensar daquilo, mas aceitei o trato.',
+3
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 1;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 2,
+'Certa noite, um homem cego bateu à porta da estalagem. Ele se apresentou como Pew e pediu para ser levado até o capitão. Algo naquele homem me deixou com os cabelos em pé.
+
+O capitão ficou pálido quando Pew lhe colocou algo na mão. Mais tarde descobri que era o papel negro, o sinal da morte entre os piratas.
+
+Naquela mesma noite, o capitão teve um ataque fulminante e morreu. Minha mãe e eu sabíamos que precisávamos agir rápido antes que os outros voltassem.',
+3
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 1;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 3,
+'Abrimos o baú do capitão à luz de uma vela tremulante. Havia roupas velhas, uma bússola, alguns papéis e, no fundo, um mapa dobrado com cuidado.
+
+O mapa mostrava uma ilha com três cruzes vermelhas e uma anotação: "Tesouro principal aqui". Era a carta náutica do lendário Capitão Flint.
+
+Fugimos com o mapa pouco antes de os piratas invadirem a estalagem. Eu podia ouvir os passos deles na estrada enquanto corríamos pela escuridão.',
+4
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 1;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 1,
+'O Esquire Trelawney ficou animadíssimo com o mapa e prometeu armar uma expedição imediatamente. Em poucas semanas, ele havia comprado um brigue chamado Hispaniola e contratado uma tripulação em Bristol.
+
+O cozinheiro do navio era um homem chamado Long John Silver, que se locomovia com uma muleta de madeira. Ele tinha um papagaio no ombro que repetia "Peças de oito!" sem parar.
+
+Silver era inteligente, bem-humorado e parecia conhecer cada porto do mundo. Eu gostei dele desde o primeiro momento, sem imaginar o que estava por vir.',
+3
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 2;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 2,
+'Na primeira noite no mar, eu não conseguia dormir. Resolvi me esconder num barril de maçãs no convés para pegar uma fruta, mas acabei adormecendo lá dentro.
+
+Acordei com vozes sussurrando bem perto. Era Silver, conversando com dois marujos. O que ouvi me gelou o sangue: ele planejava matar todos nós assim que o tesouro fosse encontrado.
+
+Fiquei imóvel, contendo a respiração, enquanto eles tramavam cada detalhe da traição. Quando eles foram embora, eu sabia que precisava avisar o capitão Smollett.',
+3
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 2;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 3,
+'Contei tudo ao doutor Livesey e ao capitão Smollett durante a madrugada. Eles me ouviram em silêncio, com rostos sérios.
+
+O capitão disse que não podíamos agir ainda, pois os piratas eram maioria a bordo. Precisávamos esperar chegar à ilha e encontrar uma oportunidade.
+
+Na manhã seguinte, avistamos a ilha no horizonte. O mapa batia perfeitamente com o que víamos: duas colinas ao norte e uma grande baía ao sul. Senti um frio na espinha que não era do vento.',
+4
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 2;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 1,
+'Desembarcamos na ilha divididos em dois grupos. Quando os piratas começaram a matar, corri para o interior da floresta sem olhar para trás.
+
+Foi então que ouvi uma voz vinda de cima de uma árvore. Era Ben Gunn, um marinheiro que havia sido abandonado na ilha há três anos. Ele estava com a barba enorme e as roupas em farrapos, mas os olhos brilhavam de inteligência.
+
+Ben me contou que conhecia o esconderijo do tesouro. Ele havia encontrado os ossos do Capitão Flint meses atrás, e desde então guardava um segredo valioso.',
+3
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 2,
+'O capitão Smollett e os homens leais se refugiaram num forte de madeira que constava no mapa. Era uma posição defensável, mas estávamos em desvantagem numérica.
+
+Os piratas atacaram ao amanhecer. A batalha foi confusa e brutal, com tiros vindos de todos os lados. Quando a fumaça baixou, havíamos perdido dois homens, mas os piratas haviam recuado.
+
+Silver hasteou uma bandeira branca no dia seguinte e veio negociar. O capitão o recusou, e Silver voltou furioso, prometendo que não teríamos misericórdia.',
+4
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 3,
+'Tomei uma decisão impulsiva durante a noite: fui sozinho até a praia e cortei as amarras do Hispaniola para deixar o navio à deriva, longe dos piratas.
+
+A operação quase me custou a vida. Passei horas boiando no mar escuro antes de conseguir subir a bordo do navio que derivava. Lá dentro, encontrei dois piratas bêbados e um deles veio me atacar com uma faca.
+
+Consegui controlar o Hispaniola e o ancorei numa pequena enseada do norte da ilha, escondido da vista dos piratas. Voltei ao forte exausto, mas satisfeito.',
+4
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 1,
+'O doutor Livesey havia entregado o mapa a Silver em troca de um acordo. Quando descobri isso, fiquei indignado, mas o doutor me olhou com um sorriso misterioso.
+
+Silver e seus homens foram até o local marcado no mapa, com eu amarrado e sendo arrastado junto. A tensão entre os piratas era palpável; eles não confiavam uns nos outros.
+
+Quando chegamos ao ponto marcado, encontramos apenas um buraco vazio na terra. O tesouro havia sumido. Os piratas explodiram em fúria e viraram as armas contra Silver.',
+3
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 2,
+'Foi então que tiros ecoaram pela floresta. O doutor Livesey, o Squire Trelawney e Ben Gunn apareceram pelos arbustos, espingardas na mão. Os piratas fugiram em pânico.
+
+Ben Gunn havia encontrado o tesouro meses antes e o havia transferido para sua caverna. Era por isso que o doutor havia entregado o mapa sem medo: ele já sabia que lá não havia mais nada.
+
+Silver, esperto como sempre, percebeu rapidamente como as coisas estavam e ficou ao nosso lado, fingindo que sempre foi leal. Nenhum de nós tinha energia para discutir.',
+3
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 3,
+'Carregamos o tesouro do Capitão Flint ao longo de dois dias exaustivos. Eram barras de ouro, moedas de dezenas de países e joias que brilhavam à luz das tochas.
+
+Deixamos os três piratas restantes na ilha com mantimentos suficientes para sobreviver. Eles preferiram ficar a enfrentar a justiça na Inglaterra.
+
+Silver desapareceu numa das noites seguintes, levando consigo uma pequena bolsa de ouro. Ninguém foi atrás dele. Chegamos à Inglaterra ricos e com histórias que nenhum de nós jamais esqueceria.',
+5
+FROM phases p
+JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4;

--- a/backend/src/main/resources/db/migration/V3__seed_initial_content.sql
+++ b/backend/src/main/resources/db/migration/V3__seed_initial_content.sql
@@ -1,9 +1,9 @@
 INSERT INTO genres (name, slug, icon_emoji, description) VALUES
-  ('Aventura', 'aventura', 'Histórias de ação, exploração e coragem'),
-  ('Terror', 'terror', 'Narrativas de suspense e medo'),
-  ('Romance', 'romance', 'Histórias de amor e relacionamentos'),
-  ('Fantasia', 'fantasia', 'Mundos mágicos e criaturas fantásticas'),
-  ('Suspense', 'suspense', 'Mistérios e reviravoltas inesperadas');
+  ('Aventura', 'aventura', NULL, 'Histórias de ação, exploração e coragem'),
+  ('Terror', 'terror', NULL, 'Narrativas de suspense e medo'),
+  ('Romance', 'romance', NULL, 'Histórias de amor e relacionamentos'),
+  ('Fantasia', 'fantasia', NULL, 'Mundos mágicos e criaturas fantásticas'),
+  ('Suspense', 'suspense', NULL, 'Mistérios e reviravoltas inesperadas');
 
 INSERT INTO books (genre_id, title, author)
 SELECT id, 'A Ilha do Tesouro', 'Robert Louis Stevenson'

--- a/backend/src/test/java/com/librum/controller/ReadingControllerIntegrationTest.java
+++ b/backend/src/test/java/com/librum/controller/ReadingControllerIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.librum.controller;
+
+import com.librum.dto.PhaseSegmentResponse;
+import com.librum.model.Genre;
+import com.librum.model.User;
+import com.librum.repository.GenreRepository;
+import com.librum.repository.UserRepository;
+import com.librum.security.JwtUtil;
+import com.librum.service.ReadingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(ReadingController.class)
+@Import(com.librum.security.SecurityConfig.class)
+public class ReadingControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ReadingService readingService;
+
+    @MockBean
+    private GenreRepository genreRepository;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    // JwtUtil mockado; validateToken retorna false por padrão
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void listGenres_semAutenticacao_retorna200() throws Exception {
+        when(genreRepository.findAll()).thenReturn(List.of(new Genre()));
+
+        mockMvc.perform(get("/genres")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void getSegment_semAutenticacao_retorna403() throws Exception {
+        mockMvc.perform(get("/reading/1/1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(username = "giuliano@librum.com")
+    void getSegment_comUsuarioAutenticado_faseDestravada_retorna200() throws Exception {
+        String email = "giuliano@librum.com";
+        UUID userId = UUID.randomUUID();
+
+        User user = new User();
+        user.setId(userId);
+        user.setEmail(email);
+
+        PhaseSegmentResponse segmentoResponse = new PhaseSegmentResponse(
+                1, 4, "Era uma vez um jovem chamado Jim Hawkins...",
+                3, "Fase 1: O Inicio da Aventura", 1,
+                "A Ilha do Tesouro", "Robert Louis Stevenson", "Aventura"
+        );
+
+        when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));
+        when(readingService.getPhaseSegment(any(UUID.class), anyLong(), anyInt()))
+                .thenReturn(segmentoResponse);
+
+        mockMvc.perform(get("/reading/1/1")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.segmentNumber").value(1))
+                .andExpect(jsonPath("$.phaseTitle").value("Fase 1: O Inicio da Aventura"))
+                .andExpect(jsonPath("$.bookTitle").value("A Ilha do Tesouro"));
+    }
+}

--- a/backend/src/test/java/com/librum/service/ProgressServiceTest.java
+++ b/backend/src/test/java/com/librum/service/ProgressServiceTest.java
@@ -1,0 +1,137 @@
+package com.librum.service;
+
+import com.librum.model.Phase;
+import com.librum.model.User;
+import com.librum.model.UserProgress;
+import com.librum.repository.PhaseRepository;
+import com.librum.repository.PhaseSegmentRepository;
+import com.librum.repository.UserProgressRepository;
+import com.librum.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ProgressServiceTest {
+
+    @Mock
+    private UserProgressRepository userProgressRepository;
+
+    @Mock
+    private PhaseRepository phaseRepository;
+
+    @Mock
+    private PhaseSegmentRepository phaseSegmentRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ProgressService progressService;
+
+    private UUID userId;
+    private User user;
+    private Phase fase1;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+
+        user = new User();
+        user.setId(userId);
+        user.setName("Giuliano");
+        user.setEmail("giuliano@librum.com");
+
+        fase1 = new Phase();
+        fase1.setId(1L);
+        fase1.setPhaseNumber(1);
+        fase1.setTitle("Fase 1: O Inicio da Aventura");
+    }
+
+    @Test
+    void markSegmentRead_primeiroSegmento_criaProgressoNovo() {
+        when(phaseRepository.findById(1L)).thenReturn(Optional.of(fase1));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userProgressRepository.findByUserIdAndPhaseId(userId, 1L)).thenReturn(Optional.empty());
+        when(phaseSegmentRepository.countByPhaseId(1L)).thenReturn(4);
+
+        ArgumentCaptor<UserProgress> captor = ArgumentCaptor.forClass(UserProgress.class);
+        when(userProgressRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        Map<String, Object> result = progressService.markSegmentRead(userId, 1L, 1);
+
+        UserProgress salvo = captor.getValue();
+        assertEquals(1, salvo.getLastSegmentRead());
+        assertFalse(salvo.isCompleted());
+        assertNull(salvo.getCompletedAt());
+
+        assertEquals(1, result.get("lastSegmentRead"));
+        assertEquals(false, result.get("phaseCompleted"));
+        assertEquals(false, result.get("nextPhaseUnlocked"));
+    }
+
+    @Test
+    void markSegmentRead_segmentoRepetido_mantemMaiorValor() {
+        when(phaseRepository.findById(1L)).thenReturn(Optional.of(fase1));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        UserProgress progressoExistente = new UserProgress();
+        progressoExistente.setUser(user);
+        progressoExistente.setPhase(fase1);
+        progressoExistente.setLastSegmentRead(2); // leitor já estava no segmento 2
+
+        when(userProgressRepository.findByUserIdAndPhaseId(userId, 1L))
+                .thenReturn(Optional.of(progressoExistente));
+        when(phaseSegmentRepository.countByPhaseId(1L)).thenReturn(4);
+        when(userProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Map<String, Object> result = progressService.markSegmentRead(userId, 1L, 1);
+
+        // Math.max(2, 1) = 2, não deve regredir
+        assertEquals(2, result.get("lastSegmentRead"));
+        assertEquals(false, result.get("phaseCompleted"));
+    }
+
+    @Test
+    void markSegmentRead_ultimoSegmento_marcaFaseComoConcluidaEAtribuiTimestamp() {
+        when(phaseRepository.findById(1L)).thenReturn(Optional.of(fase1));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userProgressRepository.findByUserIdAndPhaseId(userId, 1L)).thenReturn(Optional.empty());
+        when(phaseSegmentRepository.countByPhaseId(1L)).thenReturn(4);
+
+        ArgumentCaptor<UserProgress> captor = ArgumentCaptor.forClass(UserProgress.class);
+        when(userProgressRepository.save(captor.capture())).thenAnswer(inv -> inv.getArgument(0));
+
+        Map<String, Object> result = progressService.markSegmentRead(userId, 1L, 4);
+
+        UserProgress salvo = captor.getValue();
+        assertTrue(salvo.isCompleted(), "isCompleted deve ser true ao ler o ultimo segmento");
+        assertNotNull(salvo.getCompletedAt(), "completedAt deve ser preenchido");
+        assertEquals(true, result.get("phaseCompleted"));
+    }
+
+    @Test
+    void markSegmentRead_concluiFase_indicaDesbloqueioProximaFase() {
+        when(phaseRepository.findById(1L)).thenReturn(Optional.of(fase1));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userProgressRepository.findByUserIdAndPhaseId(userId, 1L)).thenReturn(Optional.empty());
+        when(phaseSegmentRepository.countByPhaseId(1L)).thenReturn(4);
+        when(userProgressRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        Map<String, Object> result = progressService.markSegmentRead(userId, 1L, 4);
+
+        assertEquals(true, result.get("nextPhaseUnlocked"));
+    }
+}

--- a/backend/src/test/java/com/librum/service/ReadingServiceTest.java
+++ b/backend/src/test/java/com/librum/service/ReadingServiceTest.java
@@ -1,0 +1,168 @@
+package com.librum.service;
+
+import com.librum.dto.PhaseReadingResponse;
+import com.librum.dto.PhaseSegmentResponse;
+import com.librum.model.Book;
+import com.librum.model.Genre;
+import com.librum.model.Phase;
+import com.librum.model.PhaseSegment;
+import com.librum.repository.BookRepository;
+import com.librum.repository.PhaseRepository;
+import com.librum.repository.PhaseSegmentRepository;
+import com.librum.repository.UserProgressRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ReadingServiceTest {
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private PhaseRepository phaseRepository;
+
+    @Mock
+    private PhaseSegmentRepository phaseSegmentRepository;
+
+    @Mock
+    private UserProgressRepository userProgressRepository;
+
+    @InjectMocks
+    private ReadingService readingService;
+
+    private UUID userId;
+    private Genre genre;
+    private Book book;
+    private Phase fase1;
+    private Phase fase2;
+    private Phase fase3;
+    private PhaseSegment segmento1;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+
+        genre = mock(Genre.class);
+        when(genre.getName()).thenReturn("Aventura");
+
+        book = mock(Book.class);
+        when(book.getId()).thenReturn(100L);
+        when(book.getTitle()).thenReturn("A Ilha do Tesouro");
+        when(book.getAuthor()).thenReturn("Robert Louis Stevenson");
+        when(book.getGenre()).thenReturn(genre);
+
+        fase1 = new Phase();
+        fase1.setId(1L);
+        fase1.setPhaseNumber(1);
+        fase1.setTitle("Fase 1: O Inicio da Aventura");
+        fase1.setBook(book);
+
+        fase2 = new Phase();
+        fase2.setId(2L);
+        fase2.setPhaseNumber(2);
+        fase2.setTitle("Fase 2: A Tempestade");
+        fase2.setBook(book);
+
+        fase3 = new Phase();
+        fase3.setId(3L);
+        fase3.setPhaseNumber(3);
+        fase3.setTitle("Fase 3: A Ilha");
+        fase3.setBook(book);
+
+        segmento1 = new PhaseSegment();
+        segmento1.setId(1L);
+        segmento1.setPhase(fase1);
+        segmento1.setSegmentNumber(1);
+        segmento1.setContent("Era uma vez um jovem chamado Jim Hawkins...");
+        segmento1.setEstimatedMinutes(3);
+    }
+
+    @Test
+    void getPhaseSegment_faseDestravada_retornaSegmentoCorreto() {
+        when(phaseRepository.findById(1L)).thenReturn(Optional.of(fase1));
+        when(phaseSegmentRepository.findByPhaseIdAndSegmentNumber(1L, 1)).thenReturn(Optional.of(segmento1));
+        when(phaseSegmentRepository.countByPhaseId(1L)).thenReturn(4);
+
+        PhaseSegmentResponse response = readingService.getPhaseSegment(userId, 1L, 1);
+
+        assertNotNull(response);
+        assertEquals(1, response.segmentNumber());
+        assertEquals(4, response.totalSegments());
+        assertEquals("Era uma vez um jovem chamado Jim Hawkins...", response.content());
+        assertEquals(3, response.estimatedMinutes());
+        assertEquals("Fase 1: O Inicio da Aventura", response.phaseTitle());
+        assertEquals(1, response.phaseNumber());
+    }
+
+    @Test
+    void getPhaseSegment_faseTravada_lancaAccessDeniedException() {
+        when(phaseRepository.findById(2L)).thenReturn(Optional.of(fase2));
+        when(phaseRepository.findByBookIdOrderByPhaseNumber(any())).thenReturn(List.of(fase1, fase2, fase3));
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, 1L)).thenReturn(false);
+
+        assertThrows(AccessDeniedException.class, () ->
+                readingService.getPhaseSegment(userId, 2L, 1));
+
+        verify(phaseSegmentRepository, never()).findByPhaseIdAndSegmentNumber(any(), anyInt());
+    }
+
+    @Test
+    void getPhaseSegment_segmentoInexistente_lancaEntityNotFoundException() {
+        when(phaseRepository.findById(1L)).thenReturn(Optional.of(fase1));
+        when(phaseSegmentRepository.findByPhaseIdAndSegmentNumber(1L, 99)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () ->
+                readingService.getPhaseSegment(userId, 1L, 99));
+    }
+
+    @Test
+    void getPhasesForGenre_listaFases_retornaStatusDeDesbloqueioCorreto() {
+        when(bookRepository.findByGenreId(10L)).thenReturn(Optional.of(book));
+        when(phaseRepository.findByBookIdOrderByPhaseNumber(any())).thenReturn(List.of(fase1, fase2, fase3));
+        when(phaseSegmentRepository.countByPhaseId(anyLong())).thenReturn(4);
+
+        // fase 1 concluída → fase 2 destravada; fase 2 não concluída → fase 3 travada
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, 1L)).thenReturn(true);
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, 2L)).thenReturn(false);
+
+        List<PhaseReadingResponse> fases = readingService.getPhasesForGenre(userId, 10L);
+
+        assertEquals(3, fases.size());
+        assertTrue(fases.get(0).isUnlocked(),  "Fase 1 deve estar sempre destravada");
+        assertTrue(fases.get(1).isUnlocked(),  "Fase 2 deve estar destravada pois fase 1 foi concluida");
+        assertFalse(fases.get(2).isUnlocked(), "Fase 3 deve estar travada pois fase 2 nao foi concluida");
+    }
+
+    @Test
+    void getPhasesForGenre_semProgresso_somenteFase1Destravada() {
+        when(bookRepository.findByGenreId(10L)).thenReturn(Optional.of(book));
+        when(phaseRepository.findByBookIdOrderByPhaseNumber(any())).thenReturn(List.of(fase1, fase2, fase3));
+        when(phaseSegmentRepository.countByPhaseId(anyLong())).thenReturn(4);
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, 1L)).thenReturn(false);
+
+        List<PhaseReadingResponse> fases = readingService.getPhasesForGenre(userId, 10L);
+
+        assertEquals(3, fases.size());
+        assertTrue(fases.get(0).isUnlocked(),  "Fase 1 sempre destravada");
+        assertFalse(fases.get(1).isUnlocked(), "Fase 2 travada sem progresso");
+        assertFalse(fases.get(2).isUnlocked(), "Fase 3 travada sem progresso");
+    }
+}


### PR DESCRIPTION
## Descrição

> Implementa o backend completo das US04 e US05: migration V2 com 5 novas
> tabelas (genres, books, phases, phase_segments, user_progress), migration V3
> com seed do conteúdo de "A Ilha do Tesouro", entidades JPA e repositories
> para Genre, Book, Phase, PhaseSegment e UserProgress, ReadingService
> (padrão Facade coordenando 4 repositories), ReadingController (GET /genres,
> GET /genres/{id}/phases, GET /reading/{phaseId}/{segmentNumber}),
> ProgressService e ProgressController (POST /progress/mark-read).
> Inclui 12 testes automatizados: 5 de unidade em ReadingServiceTest,
> 4 em ProgressServiceTest e 3 de integração em ReadingControllerIntegrationTest.

Closes #17
Closes #18

---

## Tipo de Mudança

- [x] Nova funcionalidade
- [ ] Correção de bug
- [ ] Melhoria de código
- [ ] Documentação
- [x] Testes
- [x] Configuração/infraestrutura

---

## Como Testar

1. Rodar `docker-compose up -d` e confirmar que o banco sobe.
2. Rodar `./mvnw spring-boot:run` na pasta `backend/` e verificar nos logs que as migrations V2 e V3 foram aplicadas sem erro.
3. Testar `GET http://localhost:8080/genres` sem token e confirmar resposta 200 com lista de 5 gêneros.
4. Fazer login via `POST /auth/login` para obter um JWT.
5. Testar `GET http://localhost:8080/genres/1/phases` com o JWT e confirmar que retorna 4 fases, sendo só a Fase 1 desbloqueada.
6. Testar `GET http://localhost:8080/reading/1/1` com o JWT e confirmar que retorna o conteúdo do primeiro segmento.
7. Testar `POST http://localhost:8080/progress/mark-read` com body `{ "phaseId": 1, "segmentNumber": 1 }` e confirmar resposta com `lastSegmentRead: 1`.
8. Rodar `./mvnw test` e confirmar que todos os 12 testes passam.

**Resultado esperado:** 12 testes passando. Endpoints respondendo conforme `docs/contrato-api-leitura.md`.

---

## Checklist

- [x] Código compila e executa sem erros
- [x] Testes adicionados/atualizados e passando
- [x] Padrões de código seguidos (lint/formatação)
- [x] Commits seguem Conventional Commits
- [x] Branch atualizada com `main`