### PR TITLE
Docs/sprint3 contratos

### DIFF
--- a/docs/adrs/ADR-0008-command-quiz-service.md
+++ b/docs/adrs/ADR-0008-command-quiz-service.md
@@ -1,0 +1,44 @@
+# ADR-0008 - Uso do padrão Command no QuizService
+
+## Contexto
+
+Seguindo o mesmo raciocínio do ADR-0007, centralizar a lógica de negócio em um serviço dedicado evita que o controller acumule responsabilidades.
+
+Quando um usuário submete as respostas de um quiz, o controller precisaria fazer várias coisas ao mesmo tempo: validar as respostas contra o banco, contar quantas acertou, calcular o XP ganho, incrementar o nível do usuário se necessário e salvar tudo. Isso espalha regras de negócio no controller, tornando-o grande demais e difícil de testar.
+
+## Decisão
+
+`QuizService.java` implementa uma adaptação do padrão Command: cada submissão de quiz é tratada como um comando único, encapsulado no método `submitQuiz(userId, phaseId, answers)`. O controller chama apenas esse método e retorna o resultado sem conhecer os detalhes de cálculo.
+
+O padrão é uma adaptação porque não há um objeto Command separado com método `execute()`, o que seria complexidade desnecessária para o escopo. O comportamento central do padrão está presente: a operação completa é encapsulada em um único ponto, isolando o controller das regras de negócio.
+
+## Alternativas consideradas
+
+- **Lógica dentro do controller** - descartado porque viola separação de responsabilidades; controller fica grande demais e difícil de testar sem mockar tudo.
+- **DTO com método execute()** - descartado porque adiciona complexidade sem ganho real; uma classe Service simples resolve o problema.
+
+## Classes afetadas
+
+- `QuizService` (implementa o Command)
+- `QuizController` (consome o Command)
+- `XpService` (chamado internamente pelo QuizService)
+- `QuizQuestionRepository`, `UserRepository` (internos ao QuizService)
+
+## O que isso implica
+
+- O controller apenas chama `quizService.submitQuiz()` e retorna o resultado.
+- Testes de `QuizService` precisam mockar `QuizQuestionRepository`, `XpService` e `UserRepository`.
+- Trade-off: se novos tipos de submissão forem adicionados (ex: bônus de tempo), o `QuizService` cresce em responsabilidade; a alternativa seria criar um novo service específico.
+
+## Exemplo de dado
+
+Questão de quiz armazenada no banco (Migration V5):
+
+```sql
+INSERT INTO quiz_questions 
+  (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index)
+VALUES
+  (1, 'Qual era o nome do tesouro procurado por Jim Hawkins?', 
+       'O Tesouro Perdido', 'O Tesouro do Flint', 'O Tesouro Enterrado', 'O Tesouro de Silver', 
+       'B', 1);
+```

--- a/docs/contrato-api-quiz.md
+++ b/docs/contrato-api-quiz.md
@@ -1,0 +1,122 @@
+# Contrato de API - Quiz e Perfil do Usuário
+
+Endpoints implementados na Sprint 3 para as US06 e US07.
+
+URL base: `http://localhost:8080`
+
+---
+
+## GET /quiz/{phaseId}
+
+Retorna as questões do quiz para uma fase, sem expor a resposta correta.
+
+**Autenticação:** `Authorization: Bearer <token>` (obrigatório).
+
+**Parâmetros de rota:**
+
+- `phaseId` (Long): identificador da fase.
+
+**Resposta 200:**
+
+```json
+[
+  {
+    "id": 1,
+    "phaseId": 1,
+    "questionText": "Quem era o capitão Flint?",
+    "optionA": "Um pirata lendário",
+    "optionB": "O pai de Jim",
+    "optionC": "Um marinheiro aposentado",
+    "optionD": "O dono da Estalagem do Almirante Benbow"
+  },
+  {
+    "id": 2,
+    "phaseId": 1,
+    "questionText": "Qual era o nome do tesouro procurado por Jim Hawkins?",
+    "optionA": "O Tesouro Perdido",
+    "optionB": "O Tesouro do Flint",
+    "optionC": "O Tesouro Enterrado",
+    "optionD": "O Tesouro de Silver"
+  }
+]
+```
+
+**Resposta 401:** token ausente ou inválido.
+
+**Resposta 404:** fase não encontrada.
+
+---
+
+## POST /quiz/{phaseId}/submit
+
+Valida as respostas do usuário, calcula o XP ganho e retorna o resultado.
+
+**Autenticação:** `Authorization: Bearer <token>` (obrigatório).
+
+**Parâmetros de rota:**
+
+- `phaseId` (Long): identificador da fase.
+
+**Corpo da requisição:**
+
+```json
+{
+  "answers": [
+    { "questionId": 1, "selectedOption": "A" },
+    { "questionId": 2, "selectedOption": "B" }
+  ]
+}
+```
+
+- `answers` (obrigatório): lista com pelo menos 1 resposta.
+- `questionId`: ID da questão.
+- `selectedOption`: aceita somente `"A"`, `"B"`, `"C"` ou `"D"` (maiúsculo).
+
+**Resposta 200:**
+
+```json
+{
+  "totalQuestions": 2,
+  "correctAnswers": 1,
+  "xpEarned": 5,
+  "newTotalXp": 45,
+  "newLevel": 1,
+  "leveledUp": false
+}
+```
+
+- `xpEarned`: +5 XP por resposta correta.
+- `newTotalXp`: XP acumulado do usuário após esta submissão.
+- `leveledUp`: `true` se o usuário atingiu um novo nível (a cada 50 XP).
+
+**Resposta 400:** payload inválido ou questões/respostas inconsistentes.
+
+**Resposta 401:** token ausente ou inválido.
+
+**Resposta 404:** fase ou questões não encontradas.
+
+---
+
+## GET /users/me
+
+Retorna o perfil do usuário autenticado com XP e nível atual.
+
+**Autenticação:** `Authorization: Bearer <token>` (obrigatório).
+
+**Resposta 200:**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "name": "João Silva",
+  "email": "joao@email.com",
+  "xp": 45,
+  "level": 1
+}
+```
+
+- `id` (UUID): identificador único do usuário.
+- `xp` (int): XP acumulado total.
+- `level` (int): nível atual entre 1 e 10.
+
+**Resposta 401:** token ausente ou inválido.


### PR DESCRIPTION
## Descrição

> Define o contrato dos 4 novos endpoints de quiz e perfil (docs/contrato-api-quiz.md)
> e registra a decisão arquitetural de aplicar o padrão Command no QuizService
> (ADR-0008).

closes #93 
---

## Tipo de Mudança

- [ ] Nova funcionalidade
- [ ] Correção de bug
- [ ] Melhoria de código
- [x] Documentação
- [ ] Testes
- [ ] Configuração/infraestrutura

---

## Como Testar

1. Abrir `docs/contrato-api-quiz.md` e confirmar que todos os 4 endpoints têm método, rota, autenticação, body e códigos de resposta.
2. Abrir `docs/adrs/ADR-0008-command-quiz-service.md` e confirmar que contexto, decisão, alternativas e implicações estão preenchidos.

---

## Checklist

- [x] Commits seguem Conventional Commits
- [x] Branch atualizada com `main`
