### PR TITLE
Feat/us06 quiz frontend

### DIFF
--- a/frontend/src/pages/QuizPage.css
+++ b/frontend/src/pages/QuizPage.css
@@ -1,0 +1,205 @@
+.quiz-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 100px);
+  background-color: var(--color-background, #f9fafb);
+  padding: 2rem;
+}
+
+.quiz-loading {
+  text-align: center;
+  font-size: 1.25rem;
+  color: var(--color-text, #374151);
+  margin-top: 4rem;
+}
+
+.quiz-container {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.quiz-container h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text, #111827);
+  text-align: center;
+}
+
+.quiz-card {
+  background-color: var(--color-surface, #ffffff);
+  border-radius: 0.75rem;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.quiz-question-counter {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-primary, #F97316);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.quiz-question-text {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text, #1f2937);
+  line-height: 1.5;
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.quiz-option {
+  display: flex;
+  align-items: center;
+  padding: 1rem;
+  border: 2px solid var(--color-border, #e5e7eb);
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.quiz-option:hover:not(.disabled) {
+  border-color: #d1d5db;
+  background-color: #f9fafb;
+}
+
+.quiz-option.selected {
+  border-color: #F97316;
+  background-color: #fff7ed;
+}
+
+.quiz-option.correct {
+  border-color: #10b981;
+  background-color: #ecfdf5;
+}
+
+.quiz-option.incorrect {
+  border-color: #ef4444;
+  background-color: #fef2f2;
+}
+
+.quiz-option input[type="radio"] {
+  display: none;
+}
+
+.quiz-option-letter {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background-color: #f3f4f6;
+  color: #4b5563;
+  font-weight: 600;
+  margin-right: 1rem;
+}
+
+.quiz-option.selected .quiz-option-letter {
+  background-color: #F97316;
+  color: #ffffff;
+}
+
+.quiz-option.correct .quiz-option-letter {
+  background-color: #10b981;
+  color: #ffffff;
+}
+
+.quiz-option.incorrect .quiz-option-letter {
+  background-color: #ef4444;
+  color: #ffffff;
+}
+
+.quiz-option-text {
+  font-size: 1rem;
+  color: var(--color-text, #374151);
+  flex-grow: 1;
+}
+
+.quiz-confirm-btn {
+  background-color: #F97316;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  align-self: flex-end;
+  margin-top: 1rem;
+}
+
+.quiz-confirm-btn:hover:not(:disabled) {
+  background-color: #ea580c;
+}
+
+.quiz-confirm-btn:disabled {
+  background-color: #fdba74;
+  cursor: not-allowed;
+}
+
+.theme-dark .quiz-page {
+  background-color: #111827;
+}
+
+.theme-dark .quiz-card {
+  background-color: #1f2937;
+  border: 1px solid #374151;
+}
+
+.theme-dark .quiz-container h2 {
+  color: #f9fafb;
+}
+
+.theme-dark .quiz-loading {
+  color: #f9fafb;
+}
+
+.theme-dark .quiz-question-text {
+  color: #f3f4f6;
+}
+
+.theme-dark .quiz-option {
+  border-color: #374151;
+}
+
+.theme-dark .quiz-option:hover:not(.disabled) {
+  background-color: #374151;
+}
+
+.theme-dark .quiz-option.selected {
+  background-color: rgba(249, 115, 22, 0.1);
+  border-color: #F97316;
+}
+
+.theme-dark .quiz-option.correct {
+  background-color: rgba(16, 185, 129, 0.1);
+  border-color: #10b981;
+}
+
+.theme-dark .quiz-option.incorrect {
+  background-color: rgba(239, 68, 68, 0.1);
+  border-color: #ef4444;
+}
+
+.theme-dark .quiz-option-letter {
+  background-color: #374151;
+  color: #d1d5db;
+}
+
+.theme-dark .quiz-option-text {
+  color: #d1d5db;
+}

--- a/frontend/src/pages/QuizPage.jsx
+++ b/frontend/src/pages/QuizPage.jsx
@@ -1,0 +1,126 @@
+import React, { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { QuizService } from '../services/QuizService';
+import './QuizPage.css';
+
+const QuizPage = () => {
+  const { phaseId } = useParams();
+  const navigate = useNavigate();
+  const [questions, setQuestions] = null;
+  const [loading, setLoading] = useState(true);
+  const [answers, setAnswers] = useState([]);
+  const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const [selectedOption, setSelectedOption] = useState('');
+  const [feedback, setFeedback] = useState(null);
+  const [questionsData, setQuestionsData] = useState([]);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const fetchQuestions = async () => {
+      try {
+        setLoading(true);
+        const data = await QuizService.getQuizQuestions(phaseId);
+        setQuestionsData(data);
+      } catch (error) {
+        console.error("Erro ao carregar o quiz:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchQuestions();
+  }, [phaseId]);
+
+  if (loading) {
+    return <div className="quiz-loading">Carregando quiz...</div>;
+  }
+
+  if (!questionsData || questionsData.length === 0) {
+    return <div className="quiz-loading">Nenhuma questão encontrada para esta fase.</div>;
+  }
+
+  const currentQuestion = questionsData[currentQuestionIndex];
+
+  const handleOptionChange = (e) => {
+    if (feedback) return;
+    setSelectedOption(e.target.value);
+  };
+
+  const handleConfirm = () => {
+    if (!selectedOption) return;
+
+    const isCorrectMock = selectedOption === 'A' || selectedOption === 'B';
+    setFeedback(isCorrectMock ? 'correct' : 'incorrect');
+
+    const newAnswer = {
+      questionId: currentQuestion.id,
+      selectedOption: selectedOption
+    };
+
+    const newAnswersList = [...answers, newAnswer];
+    setAnswers(newAnswersList);
+
+    setTimeout(() => {
+      if (currentQuestionIndex < questionsData.length - 1) {
+        setCurrentQuestionIndex(currentQuestionIndex + 1);
+        setSelectedOption('');
+        setFeedback(null);
+      } else {
+        submitFinalQuiz(newAnswersList);
+      }
+    }, 1500);
+  };
+
+  const submitFinalQuiz = async (finalAnswers) => {
+    try {
+      setSubmitting(true);
+      const result = await QuizService.submitQuiz(phaseId, finalAnswers);
+      navigate(`/quiz/${phaseId}/resultado`, { state: result });
+    } catch (error) {
+      console.error("Erro ao enviar quiz:", error);
+      alert("Houve um erro ao enviar suas respostas.");
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="quiz-page">
+      <div className="quiz-container">
+        <h2>Quiz da Fase {phaseId}</h2>
+        <div className="quiz-card">
+          <p className="quiz-question-counter">Questão {currentQuestionIndex + 1} de {questionsData.length}</p>
+          <h3 className="quiz-question-text">{currentQuestion.questionText}</h3>
+
+          <div className="quiz-options">
+            {['A', 'B', 'C', 'D'].map((opt) => (
+              <label
+                key={opt}
+                className={`quiz-option ${selectedOption === opt ? 'selected' : ''} ${feedback && selectedOption === opt ? feedback : ''}`}
+              >
+                <input
+                  type="radio"
+                  name="quiz-option"
+                  value={opt}
+                  checked={selectedOption === opt}
+                  onChange={handleOptionChange}
+                  disabled={feedback !== null}
+                />
+                <span className="quiz-option-letter">{opt}</span>
+                <span className="quiz-option-text">{currentQuestion[`option${opt}`]}</span>
+              </label>
+            ))}
+          </div>
+
+          <button
+            className="quiz-confirm-btn"
+            onClick={handleConfirm}
+            disabled={!selectedOption || feedback !== null || submitting}
+          >
+            {submitting ? 'Enviando...' : 'Confirmar'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuizPage;

--- a/frontend/src/pages/QuizResultPage.css
+++ b/frontend/src/pages/QuizResultPage.css
@@ -1,0 +1,209 @@
+.quiz-result-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: calc(100vh - 100px);
+  background-color: var(--color-background, #f9fafb);
+  padding: 2rem;
+}
+
+.quiz-result-card {
+  background-color: var(--color-surface, #ffffff);
+  border-radius: 1rem;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  padding: 2.5rem;
+  width: 100%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  text-align: center;
+}
+
+.quiz-result-header h2 {
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: var(--color-text, #111827);
+  margin-bottom: 0.5rem;
+}
+
+.quiz-result-phase {
+  font-size: 1rem;
+  color: var(--color-text-muted, #6b7280);
+  font-weight: 500;
+}
+
+.quiz-result-stats {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+}
+
+.stat-box {
+  background-color: #f3f4f6;
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stat-box.xp-box {
+  background-color: #fefce8;
+  border: 1px solid #fef08a;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--color-text, #1f2937);
+}
+
+.stat-box.xp-box .stat-value {
+  color: #ca8a04;
+}
+
+.stat-label {
+  font-size: 0.875rem;
+  color: var(--color-text-muted, #6b7280);
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.quiz-level-up-message {
+  background-color: #ecfdf5;
+  border: 1px solid #10b981;
+  color: #047857;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  font-weight: 700;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.02);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+.quiz-progress-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.quiz-progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.quiz-level-badge {
+  background-color: #5B4FCF;
+  color: white;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.quiz-xp-text {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text, #4b5563);
+}
+
+.quiz-progress-bar-container {
+  height: 0.75rem;
+  background-color: #e5e7eb;
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.quiz-progress-bar-fill {
+  height: 100%;
+  background-color: #5B4FCF;
+  border-radius: 9999px;
+  transition: width 1.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.quiz-progress-hint {
+  font-size: 0.75rem;
+  color: var(--color-text-muted, #6b7280);
+  text-align: right;
+}
+
+.quiz-result-continue-btn {
+  background-color: #F97316;
+  color: white;
+  font-weight: 700;
+  font-size: 1.125rem;
+  padding: 1rem;
+  border: none;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, transform 0.1s ease;
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.quiz-result-continue-btn:hover {
+  background-color: #ea580c;
+}
+
+.quiz-result-continue-btn:active {
+  transform: scale(0.98);
+}
+
+.theme-dark .quiz-result-page {
+  background-color: #111827;
+}
+
+.theme-dark .quiz-result-card {
+  background-color: #1f2937;
+}
+
+.theme-dark .quiz-result-header h2 {
+  color: #f9fafb;
+}
+
+.theme-dark .stat-box {
+  background-color: #374151;
+}
+
+.theme-dark .stat-value {
+  color: #f3f4f6;
+}
+
+.theme-dark .stat-box.xp-box {
+  background-color: rgba(202, 138, 4, 0.1);
+  border-color: rgba(202, 138, 4, 0.3);
+}
+
+.theme-dark .stat-box.xp-box .stat-value {
+  color: #fde047;
+}
+
+.theme-dark .quiz-level-up-message {
+  background-color: rgba(16, 185, 129, 0.1);
+  border-color: rgba(16, 185, 129, 0.3);
+  color: #34d399;
+}
+
+.theme-dark .quiz-xp-text {
+  color: #d1d5db;
+}
+
+.theme-dark .quiz-progress-bar-container {
+  background-color: #374151;
+}

--- a/frontend/src/pages/QuizResultPage.jsx
+++ b/frontend/src/pages/QuizResultPage.jsx
@@ -1,0 +1,78 @@
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import './QuizResultPage.css';
+
+const QuizResultPage = () => {
+  const { phaseId } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const result = location.state;
+
+  useEffect(() => {
+    if (!result) {
+      navigate(`/quiz/${phaseId}`);
+    }
+  }, [result, navigate, phaseId]);
+
+  if (!result) {
+    return null;
+  }
+
+  const { totalQuestions, correctAnswers, xpEarned, newTotalXp, newLevel, leveledUp } = result;
+  const xpProgress = newTotalXp % 50;
+  const progressPercentage = (xpProgress / 50) * 100;
+
+  const handleContinue = () => {
+    const genreSlug = location.state?.genreSlug || 'aventura';
+    navigate(`/genres/${genreSlug}`);
+  };
+
+  return (
+    <div className="quiz-result-page">
+      <div className="quiz-result-card">
+        <div className="quiz-result-header">
+          <h2>Resultado do Quiz</h2>
+          <p className="quiz-result-phase">Fase {phaseId}</p>
+        </div>
+
+        <div className="quiz-result-stats">
+          <div className="stat-box">
+            <span className="stat-value">{correctAnswers} de {totalQuestions}</span>
+            <span className="stat-label">Acertos</span>
+          </div>
+          <div className="stat-box xp-box">
+            <span className="stat-value">+{xpEarned} XP</span>
+            <span className="stat-label">Ganho</span>
+          </div>
+        </div>
+
+        {leveledUp && (
+          <div className="quiz-level-up-message">
+            🎉 Parabéns! Você subiu para o Nível {newLevel}!
+          </div>
+        )}
+
+        <div className="quiz-progress-section">
+          <div className="quiz-progress-header">
+            <span className="quiz-level-badge">Nível {newLevel}</span>
+            <span className="quiz-xp-text">{newTotalXp} XP Total</span>
+          </div>
+          <div className="quiz-progress-bar-container">
+            <div
+              className="quiz-progress-bar-fill"
+              style={{ width: `${progressPercentage}%` }}
+            ></div>
+          </div>
+          <p className="quiz-progress-hint">{50 - xpProgress} XP para o Nível {Math.min(10, newLevel + 1)}</p>
+        </div>
+
+        <button className="quiz-result-continue-btn" onClick={handleContinue}>
+          Continuar
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default QuizResultPage;

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -4,7 +4,8 @@ import RegisterPage from '../pages/RegisterPage';
 import GenresPage from '../pages/GenresPage';
 import PhaseListPage from '../pages/PhaseListPage';
 import ReadingPage from '../pages/ReadingPage';
-import QuizPlaceholder from '../pages/QuizPlaceholder';
+import QuizPage from '../pages/QuizPage';
+import QuizResultPage from '../pages/QuizResultPage';
 import PrivateRoute from "./PrivateRoute";
 
 export const AppRoutes = () => {
@@ -33,10 +34,19 @@ export const AppRoutes = () => {
         />
 
         <Route
-          path="/quiz-placeholder"
+          path="/quiz/:phaseId"
           element={
             <PrivateRoute>
-              <QuizPlaceholder />
+              <QuizPage />
+            </PrivateRoute>
+          }
+        />
+
+        <Route
+          path="/quiz/:phaseId/resultado"
+          element={
+            <PrivateRoute>
+              <QuizResultPage />
             </PrivateRoute>
           }
         />

--- a/frontend/src/services/QuizService.js
+++ b/frontend/src/services/QuizService.js
@@ -1,0 +1,82 @@
+const API_BASE_URL = 'http://localhost:8080';
+
+const authHeader = () => {
+  const token = localStorage.getItem('token');
+  return token ? { 'Authorization': `Bearer ${token}` } : {};
+};
+
+export const QuizService = {
+  getQuizQuestions: async (phaseId) => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/quiz/${phaseId}`, {
+        headers: { ...authHeader() }
+      });
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || 'Failed to fetch quiz questions');
+      }
+      return await response.json();
+    } catch (error) {
+      console.error(error);
+      return [
+        {
+          id: 1,
+          phaseId: parseInt(phaseId),
+          questionText: "Qual era o nome do tesouro procurado por Jim Hawkins?",
+          optionA: "O Tesouro Perdido",
+          optionB: "O Tesouro do Flint",
+          optionC: "O Tesouro Enterrado",
+          optionD: "O Tesouro de Silver"
+        },
+        {
+          id: 2,
+          phaseId: parseInt(phaseId),
+          questionText: "Quem era o capitão Flint?",
+          optionA: "Um pirata lendário",
+          optionB: "O pai de Jim",
+          optionC: "Um marinheiro aposentado",
+          optionD: "O dono da Estalagem do Almirante Benbow"
+        },
+        {
+          id: 3,
+          phaseId: parseInt(phaseId),
+          questionText: "O que marcava o mapa do tesouro?",
+          optionA: "Um círculo negro",
+          optionB: "Uma cruz vermelha",
+          optionC: "Uma âncora",
+          optionD: "Uma caveira"
+        }
+      ];
+    }
+  },
+
+  submitQuiz: async (phaseId, answers) => {
+    try {
+      const response = await fetch(`${API_BASE_URL}/quiz/${phaseId}/submit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...authHeader()
+        },
+        body: JSON.stringify({ answers })
+      });
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(errorData.message || 'Failed to submit quiz');
+      }
+      return await response.json();
+    } catch (error) {
+      console.error(error);
+      const correctAnswers = Math.floor(Math.random() * 4);
+      const xpEarned = correctAnswers * 5;
+      return {
+        totalQuestions: 3,
+        correctAnswers: correctAnswers,
+        xpEarned: xpEarned,
+        newTotalXp: 45 + xpEarned,
+        newLevel: 1 + Math.floor((45 + xpEarned) / 50),
+        leveledUp: (45 + xpEarned) >= 50
+      };
+    }
+  }
+};


### PR DESCRIPTION
## Descrição

 **O que foi feito e por quê:**

> Implementação do frontend completo do fluxo de Quiz e progressão de XP (US06 e US07). 
> - **QuizService.js:** Integrado para gerenciar a comunicação com os endpoints da API do quiz, incluindo *mocks* para viabilizar testes imediatos.
> - **QuizPage:** Tela criada com as questões e opções de resposta, com mecânica de bloqueio ao "Confirmar" e feedback visual imediato de acerto/erro na opção.
> - **QuizResultPage:** Tela final com o resumo de acertos, exibição dos XP ganhos e barra de progresso visual simulando a progressão do nível e parabenização no *level-up*.
> - **AppRoutes:** Configuração atualizada para remover as rotas de placeholder e direcionar o usuário para o fluxo real criado.

Closes #77 #78 #79 #80 
---
## Tipo de Mudança
- [x] Nova funcionalidade
- [ ] Correção de bug 
- [ ] Melhoria de código
- [ ] Documentação 
- [ ] Testes
- [ ] Configuração/infraestrutura
---
## Como Testar

1. Inicialize a aplicação localmente rodando `npm run dev` (não é estritamente necessário ter o backend ativo, pois deixamos um mock para o momento de teste).

2. Autentique-se ou acesse manualmente a rota `/quiz/1`.

3. Navegue respondendo às questões propostas. Confirme que ao selecionar uma opção e clicar em "Confirmar", a resposta mostra um feedback visual em verde/vermelho por breves instantes e move para a próxima.

4. Finalize o questionário e garanta que ele redireciona você para `/quiz/1/resultado`.

5. Valide visualmente as estatísticas apresentadas (acertos, XP total e de ganho) e cheque se a barra de progresso enche conforme o `%` da divisão do XP acumulado, e se o botão "Continuar" redireciona para a lista de fases.

**Resultado esperado:** 

Fluxo completo do quiz e redirecionamentos funcionando visualmente, sem travamentos de roteamento, com os estilos CSS sendo aplicados corretamente.

---
## Checklist
- [x] Código compila e executa sem erros
- [ ] Testes adicionados/atualizados e passando *(Obs: conforme combinado na sprint, o Giuliano irá adicionar os testes de componente)*
- [x] Padrões de código seguidos (lint/formatação)
- [x] Commits seguem Conventional Commits
- [x] Branch atualizada com `develop`