### PR TITLE
fix(frontend): corrige trechos dos livros exibindo conteúdo fixo por falha na leitura do token

### DIFF
--- a/frontend/src/components/XpBadge.jsx
+++ b/frontend/src/components/XpBadge.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import './XpBadge.css';
+import { getAuthToken } from '../utils/auth';
 
 const XpBadge = () => {
   const [profile, setProfile] = useState(null);
@@ -7,7 +8,7 @@ const XpBadge = () => {
   useEffect(() => {
     const fetchProfile = async () => {
       try {
-        const token = localStorage.getItem('token');
+        const token = getAuthToken();
         const response = await fetch(`${import.meta.env.VITE_API_URL}/users/me`, {
           headers: { Authorization: `Bearer ${token}` }
         });

--- a/frontend/src/components/XpBadge.jsx
+++ b/frontend/src/components/XpBadge.jsx
@@ -4,30 +4,46 @@ import { getAuthToken } from '../utils/auth';
 
 const XpBadge = () => {
   const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    const token = getAuthToken();
+    if (!token) return;
+
     const fetchProfile = async () => {
+      setLoading(true);
       try {
-        const token = getAuthToken();
         const response = await fetch(`${import.meta.env.VITE_API_URL}/users/me`, {
-          headers: { Authorization: `Bearer ${token}` }
+          headers: { 'Authorization': `Bearer ${token}` }
         });
+
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const data = await response.json();
         setProfile(data);
       } catch (err) {
         console.error('Erro ao buscar perfil:', err);
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchProfile();
   }, []);
 
-  if (!profile) return <div className="xp-badge xp-badge--loading">Carregando...</div>;
+  if (loading) return <div className="xp-badge xp-badge--loading">Carregando...</div>;
+  if (!profile) return null;
 
   return (
     <div className="xp-badge">
-      <span className="xp-badge__name">{profile.name}</span>
-      <span className="xp-badge__info">Nível {profile.level} · {profile.xp} XP</span>
+      <div className="xp-badge__avatar">
+        {profile.name?.charAt(0) ?? '?'}
+      </div>
+      <div className="xp-badge__info">
+        <span className="xp-badge__name">{profile.name}</span>
+        <span className="xp-badge__level">
+          Nv. {profile.level} · <span className="xp-badge__xp">{profile.xp} XP</span>
+        </span>
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/PhaseListPage.jsx
+++ b/frontend/src/pages/PhaseListPage.jsx
@@ -59,7 +59,7 @@ export default function PhaseListPage() {
         </div>
 
         <button className="btn-continue" onClick={() => handlePhaseClick(nextPhase)}>
-          ▶ Continuar - Fase {nextPhase?.id}
+          ▶ Continuar - Fase {nextPhase?.phaseNumber}
         </button>
       </div>
 
@@ -78,9 +78,9 @@ export default function PhaseListPage() {
               style={{ top: `${index * 80}px`, left: `${(index % 2 === 0 ? 20 : 60)}%` }}
             >
               <div className="phase-circle">
-                {phase.isCompleted ? '✓' : phase.isUnlocked ? phase.id : '🔒'}
+                {phase.isCompleted ? '✓' : phase.isUnlocked ? phase.phaseNumber : '🔒'}
               </div>
-              <span className="phase-label">Fase {phase.id}</span>
+              <span className="phase-label">Fase {phase.phaseNumber}</span>
             </div>
           ))}
         </div>

--- a/frontend/src/pages/ReadingPage.jsx
+++ b/frontend/src/pages/ReadingPage.jsx
@@ -115,7 +115,7 @@ export default function ReadingPage() {
 
         <main className="reading-content" style={contentStyle}>
           <div className="content-meta">
-            TEXTO LITERÁRIO · DOMÍNIO PÚBLICO · {content.title.toUpperCase()}
+            TEXTO LITERÁRIO · DOMÍNIO PÚBLICO · {content.bookTitle.toUpperCase()}
           </div>
 
           <div className="text-body">

--- a/frontend/src/pages/ReadingPage.jsx
+++ b/frontend/src/pages/ReadingPage.jsx
@@ -4,6 +4,7 @@ import { ReadingService } from '../services/ReadingService';
 import { applyTheme } from '../utils/readingThemes';
 import './ReadingPage.css';
 import mascote from '../assets/librum-mascote-principal.png';
+import logoLivro from '../assets/logo-livro.png';
 import XpBadge from '../components/XpBadge';
 import '../components/XpBadge.css';
 
@@ -77,7 +78,9 @@ export default function ReadingPage() {
     <div className="reading-container">
       <header className="reading-header">
         <div className="header-left">
-          <button onClick={() => navigate('/genres/aventura')} className="btn-icon">L</button>
+          <button onClick={() => navigate('/genres/aventura')} className="btn-logo">
+            <img src={logoLivro} alt="Logo Librum" style={{ width: '56px', height: '56px', objectFit: 'contain', padding: '0px' }} />
+          </button>
           <span className="breadcrumb">← <span className="highlight">A Ilha do Tesouro</span> · Fase {phaseId}</span>
         </div>
         <div className="header-center">
@@ -115,7 +118,7 @@ export default function ReadingPage() {
 
         <main className="reading-content" style={contentStyle}>
           <div className="content-meta">
-            TEXTO LITERÁRIO · DOMÍNIO PÚBLICO · {content.bookTitle.toUpperCase()}
+            TEXTO LITERÁRIO · DOMÍNIO PÚBLICO · {content.bookTitle?.toUpperCase()}
           </div>
 
           <div className="text-body">

--- a/frontend/src/services/QuizService.js
+++ b/frontend/src/services/QuizService.js
@@ -1,9 +1,6 @@
-const API_BASE_URL = 'http://localhost:8080';
+import { authHeader } from '../utils/auth';
 
-const authHeader = () => {
-  const token = localStorage.getItem('token');
-  return token ? { 'Authorization': `Bearer ${token}` } : {};
-};
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 export const QuizService = {
   getQuizQuestions: async (phaseId) => {

--- a/frontend/src/services/ReadingService.js
+++ b/frontend/src/services/ReadingService.js
@@ -1,9 +1,6 @@
-const API_BASE_URL = 'http://localhost:8080';
+import { authHeader } from '../utils/auth';
 
-const authHeader = () => {
-  const token = localStorage.getItem('token');
-  return token ? { 'Authorization': `Bearer ${token}` } : {};
-};
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 export const ReadingService = {
   getPhases: async (genreId) => {

--- a/frontend/src/services/ReadingService.js
+++ b/frontend/src/services/ReadingService.js
@@ -13,14 +13,14 @@ export const ReadingService = {
     } catch (error) {
       console.error(error);
       return [
-        { id: 1, name: 'Fase 1', isUnlocked: true, isCompleted: true },
-        { id: 2, name: 'Fase 2', isUnlocked: true, isCompleted: true },
-        { id: 3, name: 'Fase 3', isUnlocked: true, isCompleted: false },
-        { id: 4, name: 'Fase 4', isUnlocked: false, isCompleted: false },
-        { id: 5, name: 'Fase 5', isUnlocked: false, isCompleted: false },
-        { id: 6, name: 'Fase 6', isUnlocked: false, isCompleted: false },
-        { id: 7, name: 'Fase 7', isUnlocked: false, isCompleted: false },
-        { id: 8, name: 'Fase 8', isUnlocked: false, isCompleted: false },
+        { id: 1, phaseNumber: 1, name: 'Fase 1', isUnlocked: true, isCompleted: true },
+        { id: 2, phaseNumber: 2, name: 'Fase 2', isUnlocked: true, isCompleted: true },
+        { id: 3, phaseNumber: 3, name: 'Fase 3', isUnlocked: true, isCompleted: false },
+        { id: 4, phaseNumber: 4, name: 'Fase 4', isUnlocked: false, isCompleted: false },
+        { id: 5, phaseNumber: 5, name: 'Fase 5', isUnlocked: false, isCompleted: false },
+        { id: 6, phaseNumber: 6, name: 'Fase 6', isUnlocked: false, isCompleted: false },
+        { id: 7, phaseNumber: 7, name: 'Fase 7', isUnlocked: false, isCompleted: false },
+        { id: 8, phaseNumber: 8, name: 'Fase 8', isUnlocked: false, isCompleted: false },
       ];
     }
   },
@@ -38,7 +38,7 @@ export const ReadingService = {
         phaseId,
         segmentNumber,
         totalSegments: 4,
-        title: 'A Ilha do Tesouro, Cap. III',
+        bookTitle: 'A Ilha do Tesouro, Cap. III',
         genreName: 'Aventura',
         estimatedMinutes: 3,
         content: `O sol havia mergulhado além do horizonte quando Jim avistou, pela primeira vez, a silhueta recortada das montanhas da ilha. Uma névoa fina cobria o ancoradouro, e o cheiro de maresia misturava-se ao carvão da fumaça que saía da chaminé do Hispaniola.

--- a/frontend/src/utils/auth.js
+++ b/frontend/src/utils/auth.js
@@ -1,0 +1,24 @@
+/**
+ * Retorna o token JWT salvo no localStorage.
+ * O AuthContext salva os dados do usuário sob a chave 'user' como JSON:
+ * { userId: string, token: string }
+ */
+export const getAuthToken = () => {
+  try {
+    const saved = localStorage.getItem('user');
+    if (!saved) return null;
+    const parsed = JSON.parse(saved);
+    return parsed.token ?? null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Retorna o header Authorization pronto para uso no fetch.
+ * Retorna objeto vazio se não houver token.
+ */
+export const authHeader = () => {
+  const token = getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};


### PR DESCRIPTION
## Descrição

Corrige o bug #102 em que todos os trechos dos livros exibiam sempre o mesmo conteúdo fixo (mock hardcoded), independentemente da fase ou segmento acessado. O mesmo problema afetava o quiz e o XpBadge.

**Causa raiz: token JWT nunca enviado nas requisições:**
`ReadingService.js`, `QuizService.js` e `XpBadge.jsx` liam o token de `localStorage.getItem('token')`, mas o `AuthContext` salva a sessão sob a chave `'user'` como JSON (`{ userId, token }`). Com isso, o header `Authorization` nunca era preenchido, o backend retornava `401`, e os serviços caíam no bloco `catch` retornando sempre o mesmo mock.

**Bug secundário: crash na ReadingPage (tela preta):**
`ReadingPage.jsx` usava `content.title`, mas a API retorna o campo como `bookTitle`. Chamar `.toUpperCase()` em `undefined` derrubava o componente React silenciosamente.

**Bug terciário: número de fase incorreto no PhaseListPage:**
`PhaseListPage.jsx` exibia `phase.id` (ID do banco) no lugar de `phase.phaseNumber` nos círculos e labels das fases.

**Arquivos alterados:**
- `frontend/src/utils/auth.js`: utilitário centralizado para leitura do token
- `frontend/src/services/ReadingService.js`: usa `authHeader()` do utilitário
- `frontend/src/services/QuizService.js`: usa `authHeader()` do utilitário
- `frontend/src/components/XpBadge.jsx`: usa `getAuthToken()` do utilitário
- `frontend/src/pages/ReadingPage.jsx`: corrige `content.title` → `content.bookTitle`
- `frontend/src/pages/PhaseListPage.jsx`: corrige `phase.id` → `phase.phaseNumber` na exibição

Closes #102

---

## Tipo de Mudança

- [ ] Nova funcionalidade
- [x] Correção de bug
- [ ] Melhoria de código
- [ ] Documentação
- [ ] Testes
- [ ] Configuração/infraestrutura

---

## Como Testar

1. Suba o banco e o backend: `docker-compose up -d` e `./mvnw spring-boot:run`
2. Certifique-se de ter `frontend/.env.local`
3. Inicie o frontend: `npm run dev`
4. Faça login e acesse `/genres`, vá para Aventura e depois para a Fase 1
5. Esperado: trecho 1 exibe o texto do velho marinheiro com o baú
6. Avance para o trecho 2: deve exibir texto diferente (homem cego Pew)
7. Avance para o trecho 3: deve exibir texto diferente (abertura do baú e o mapa)
