### PR TITLE
Docs/atualizacao contratos

### DIFF
--- a/docs/adrs/ADR-0009-template-method-phase-unlock.md
+++ b/docs/adrs/ADR-0009-template-method-phase-unlock.md
@@ -1,0 +1,42 @@
+# ADR-0009 - Template Method na verificação de desbloqueio de fases
+
+## Contexto
+
+Na Sprint 2 definimos que a Fase N ficaria desbloqueada quando o usuário tivesse lido todos os segmentos da Fase N-1 (`is_completed = true`). Essa regra foi implementada em `ReadingService.isPhaseUnlocked()`, que consulta `UserProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue`.
+
+Nesta sprint, o critério mudou: o desbloqueio passa a depender da conclusão do quiz da fase anterior (`quiz_completed = true`), e não mais apenas da leitura. Ler todos os segmentos sem concluir o quiz não desbloqueia mais a próxima fase.
+
+A questão era como aplicar essa troca sem espalhar `if` espalhados pelo service e sem reescrever o fluxo de verificação inteiro.
+
+## Decisão
+
+`ReadingService.isPhaseUnlocked()` mantém um esqueleto fixo de verificação e delega o critério de conclusão ao `UserProgressRepository`. O esqueleto faz três coisas, em ordem:
+
+1. Se a fase é a primeira do livro, retorna `true`.
+2. Localiza a fase anterior pelo `phaseNumber - 1` dentro do mesmo livro.
+3. Consulta o repositório para saber se a fase anterior atende ao critério de conclusão.
+
+O passo 3 é a parte variável. Nesta sprint, troca-se a chamada de `existsByUserIdAndPhaseIdAndIsCompletedTrue` por `existsByUserIdAndPhaseIdAndQuizCompletedTrue`. Nenhuma outra linha de `isPhaseUnlocked()` muda.
+
+Essa é uma adaptação do padrão Template Method. O esqueleto do algoritmo fica no service e o passo variável é delegado a um colaborador (o repository), em vez de a uma subclasse. A intenção do padrão (manter a estrutura geral fixa e permitir variação em um único ponto) é preservada.
+
+## Alternativas consideradas
+
+- **Lógica de desbloqueio dentro do controller**: descartado porque acopla a verificação à camada HTTP e impede reaproveitamento em outros pontos do service.
+- **Strategy com interface `PhaseUnlockPolicy`**: descartado por excesso de cerimônia. Não há previsão concreta de termos múltiplas políticas convivendo no MVP; uma interface, mais uma classe por estratégia e a injeção da política tornariam o código mais difícil de ler sem benefício imediato.
+- **Manter o nome do método antigo (`isCompletedTrue`) e mudar o significado da coluna**: descartado porque criaria divergência entre o nome do campo no banco e o que ele representa.
+
+## Classes afetadas
+
+- `ReadingService` (mantém o esqueleto do algoritmo).
+- `UserProgressRepository` (ganha o método `existsByUserIdAndPhaseIdAndQuizCompletedTrue` e mantém o anterior para rastreio de leitura).
+- `UserProgress` (ganha o campo `quizCompleted`).
+- `QuizService` (passa a marcar `quizCompleted = true` no `UserProgress` quando o quiz é aprovado).
+
+## O que isso implica
+
+Trocar a regra de desbloqueio no futuro (por exemplo, exigir tanto leitura quanto quiz, ou exigir uma nota mínima) significa alterar somente a chamada feita no passo 3 de `isPhaseUnlocked()`. O esqueleto, o controller e o restante do service não são afetados.
+
+A coluna `is_completed` continua sendo persistida pelo `ProgressService` quando o usuário lê o último segmento, mas deixa de ser o critério de desbloqueio. Ela permanece útil para indicar visualmente, na trilha de fases, se a leitura foi concluída independentemente do quiz.
+
+Trade-off: a abstração só compensa enquanto a verificação envolver uma única chamada ao repository. Se a regra evoluir para combinar várias verificações (por exemplo, leitura concluída E quiz aprovado E nota mínima), valerá reavaliar entre manter o Template Method aqui ou migrar para Strategy.

--- a/docs/contrato-api-leitura.md
+++ b/docs/contrato-api-leitura.md
@@ -1,6 +1,6 @@
-# Contrato de API — Leitura e Progresso
+# Contrato de API - Leitura e Progresso
 
-Endpoints implementados na Sprint 2 para as US04 e US05.
+Endpoints implementados na Sprint 2 (US04 e US05) e ajustados na Sprint 3-2 (US08 e US09).
 
 URL base: `http://localhost:8080`
 
@@ -65,8 +65,8 @@ Lista as fases do livro disponível para um gênero, com o status de desbloqueio
 ]
 ```
 
-- `isUnlocked`: `true` para a Fase 1 sempre; `true` para a Fase N se a Fase N-1 está com `isCompleted = true`.
-- `isCompleted`: `true` se o usuário leu todos os segmentos da fase.
+- `isUnlocked`: `true` para a Fase 1 sempre; `true` para a Fase N quando o quiz da Fase N-1 foi concluído (`quiz_completed = true` em `user_progress`).
+- `isCompleted`: `true` se o usuário leu todos os segmentos da fase. Por si só não desbloqueia a próxima fase: o desbloqueio depende da conclusão do quiz.
 
 **Resposta 401:** token ausente ou inválido.
 
@@ -95,13 +95,16 @@ Retorna o conteúdo de um segmento de texto de uma fase.
   "phaseNumber": 1,
   "bookTitle": "A Ilha do Tesouro",
   "bookAuthor": "Robert Louis Stevenson",
-  "genreName": "Aventura"
+  "genreName": "Aventura",
+  "genreSlug": "aventura"
 }
 ```
 
+- `genreSlug`: slug do gênero da fase. O frontend usa esse valor para construir links de navegação (breadcrumb e botão de voltar) sem fixar a string `"aventura"` no código.
+
 **Resposta 401:** token ausente ou inválido.
 
-**Resposta 403:** fase bloqueada para o usuário (fase anterior não concluída).
+**Resposta 403:** fase bloqueada para o usuário (quiz da fase anterior não concluído).
 
 **Resposta 404:** segmento não existe na fase.
 

--- a/docs/contrato-api-quiz.md
+++ b/docs/contrato-api-quiz.md
@@ -1,6 +1,6 @@
 # Contrato de API - Quiz e Perfil do Usuário
 
-Endpoints implementados na Sprint 3 para as US06 e US07.
+Endpoints implementados na Sprint 3 (US06 e US07) e estendidos na Sprint 3-2 (US08 e US09).
 
 URL base: `http://localhost:8080`
 
@@ -8,7 +8,7 @@ URL base: `http://localhost:8080`
 
 ## GET /quiz/{phaseId}
 
-Retorna as questões do quiz para uma fase, sem expor a resposta correta.
+Retorna as questões do quiz para uma fase, incluindo a letra da opção correta e o texto de explicação. A validação da submissão continua sendo feita no backend em `POST /quiz/{phaseId}/submit`; expor a letra aqui serve apenas para o frontend destacar a opção certa quando o usuário erra.
 
 **Autenticação:** `Authorization: Bearer <token>` (obrigatório).
 
@@ -27,7 +27,9 @@ Retorna as questões do quiz para uma fase, sem expor a resposta correta.
     "optionA": "Um pirata lendário",
     "optionB": "O pai de Jim",
     "optionC": "Um marinheiro aposentado",
-    "optionD": "O dono da Estalagem do Almirante Benbow"
+    "optionD": "O dono da Estalagem do Almirante Benbow",
+    "correctOption": "A",
+    "explanation": "Capitão Flint era o pirata lendário que enterrou o tesouro procurado na história."
   },
   {
     "id": 2,
@@ -36,10 +38,15 @@ Retorna as questões do quiz para uma fase, sem expor a resposta correta.
     "optionA": "O Tesouro Perdido",
     "optionB": "O Tesouro do Flint",
     "optionC": "O Tesouro Enterrado",
-    "optionD": "O Tesouro de Silver"
+    "optionD": "O Tesouro de Silver",
+    "correctOption": "B",
+    "explanation": "O tesouro procurado pertencia ao Capitão Flint, daí o nome usado pelos personagens."
   }
 ]
 ```
+
+- `correctOption`: letra da opção correta (`"A"`, `"B"`, `"C"` ou `"D"`).
+- `explanation`: texto curto exibido após o usuário confirmar a resposta de cada questão.
 
 **Resposta 401:** token ausente ou inválido.
 
@@ -49,7 +56,7 @@ Retorna as questões do quiz para uma fase, sem expor a resposta correta.
 
 ## POST /quiz/{phaseId}/submit
 
-Valida as respostas do usuário, calcula o XP ganho e retorna o resultado.
+Valida as respostas do usuário, calcula o XP ganho e marca a fase como concluída quando o usuário acerta o suficiente. A conclusão do quiz é o que desbloqueia a próxima fase na trilha.
 
 **Autenticação:** `Authorization: Bearer <token>` (obrigatório).
 
@@ -72,22 +79,43 @@ Valida as respostas do usuário, calcula o XP ganho e retorna o resultado.
 - `questionId`: ID da questão.
 - `selectedOption`: aceita somente `"A"`, `"B"`, `"C"` ou `"D"` (maiúsculo).
 
-**Resposta 200:**
+**Resposta 200 quando aprovado:**
 
 ```json
 {
-  "totalQuestions": 2,
+  "totalQuestions": 4,
+  "correctAnswers": 3,
+  "xpEarned": 15,
+  "newTotalXp": 60,
+  "newLevel": 2,
+  "leveledUp": true,
+  "nextPhaseId": 2,
+  "passed": true
+}
+```
+
+**Resposta 200 quando reprovado (mais de 2 erros):**
+
+```json
+{
+  "totalQuestions": 4,
   "correctAnswers": 1,
   "xpEarned": 5,
   "newTotalXp": 45,
   "newLevel": 1,
-  "leveledUp": false
+  "leveledUp": false,
+  "nextPhaseId": null,
+  "passed": false
 }
 ```
 
-- `xpEarned`: +5 XP por resposta correta.
+- `xpEarned`: +5 XP por resposta correta, independente de aprovado ou reprovado.
 - `newTotalXp`: XP acumulado do usuário após esta submissão.
 - `leveledUp`: `true` se o usuário atingiu um novo nível (a cada 50 XP).
+- `passed`: `true` quando `totalQuestions - correctAnswers <= 2`.
+- `nextPhaseId`: ID da próxima fase quando `passed = true` e existe próxima fase no livro. `null` se reprovado ou se for a última fase.
+
+**Efeito colateral:** quando `passed = true`, o registro em `user_progress` recebe `quiz_completed = true` e `is_completed = true` para o par (usuário, fase). Quando `passed = false`, nada é alterado em `user_progress` e a próxima fase permanece bloqueada.
 
 **Resposta 400:** payload inválido ou questões/respostas inconsistentes.
 


### PR DESCRIPTION
## Descrição

  > O que foi feito e por quê:

  - Atualiza `docs/contrato-api-quiz.md`: `GET /quiz/{phaseId}` passa a expor `correctOption` e `explanation` (necessário para o frontend mostrar acerto/erro com explicação por questão). `POST /quiz/{phaseId}/submit` passa a retornar `passed` e `nextPhaseId`, e marca `quiz_completed = true` no `user_progress` quando aprovado.
  - Atualiza `docs/contrato-api-leitura.md`: regra de `isUnlocked` em `GET /genres/{genreId}/phases` muda para depender de `quiz_completed`. `GET /reading/{phaseId}/{segmentNumber}` ganha o campo `genreSlug` para o frontend remover o hardcode da string "aventura".
  - Adiciona `docs/adrs/ADR-0009-template-method-phase-unlock.md` registrando a aplicação de Template Method em `ReadingService.isPhaseUnlocked()` para suportar a troca do critério de desbloqueio (leitura -> quiz) sem reescrever o fluxo.
  
  Closes #106 

  ---

  ## Tipo de Mudança

  - [ ] Nova funcionalidade
  - [ ] Correção de bug
  - [ ] Melhoria de código
  - [x] Documentação
  - [ ] Testes
  - [ ] Configuração/infraestrutura

  ---

  ## Como Testar

  1. Fazer checkout da branch `docs/atualizacao-contratos`.
  2. Abrir `docs/contrato-api-quiz.md` e conferir que `GET /quiz/{phaseId}` lista `correctOption` e `explanation` e que `POST /quiz/{phaseId}/submit` documenta os dois cenários (aprovado e reprovado) com `passed` e `nextPhaseId`.
  3. Abrir `docs/contrato-api-leitura.md` e conferir a nova regra de `isUnlocked` e o campo `genreSlug` no response do reading.
  4. Abrir `docs/adrs/ADR-0009-template-method-phase-unlock.md` e revisar contexto, decisão, alternativas consideradas e implicações.

  **Resultado esperado:** os três arquivos descrevem com precisão o comportamento e o payload que serão implementados nos blocos de backend desta sprint, sem divergência entre eles.

  ---

  ## Checklist

  - [x] Código compila e executa sem erros (PR de documentação, sem código)
  - [x] Testes adicionados/atualizados e passando (não aplicável)
  - [x] Padrões de código seguidos (lint/formatação)
  - [x] Commits seguem Conventional Commits
  - [x] Branch atualizada com `main`