### PR TITLE
fix(frontend): corrige bugs criticos, integra Navbar via Layout, tril…

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Navbar from './Navbar';
+
+export default function Layout({ children }) {
+  return (
+    <div className="app-layout" style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+      <Navbar />
+      <main style={{ flex: 1 }}>{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.css
+++ b/frontend/src/components/Navbar.css
@@ -1,0 +1,38 @@
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: var(--color-surface, #ffffff);
+  border-bottom: 1px solid var(--color-border, #eaeaea);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.navbar-logo {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--color-primary, #3A2F80);
+  text-decoration: none;
+}
+
+.navbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.btn-logout {
+  background: none;
+  border: 1.5px solid var(--color-border, #eaeaea);
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md, 8px);
+  color: var(--color-text-muted, #666);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast, 0.2s);
+}
+
+.btn-logout:hover {
+  border-color: var(--color-text, #333);
+  color: var(--color-text, #333);
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import XpBadge from './XpBadge';
+import './Navbar.css';
+
+export default function Navbar() {
+  const { logoutUser } = useAuth();
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logoutUser();
+    navigate('/login');
+  };
+
+  return (
+    <nav className="navbar">
+      <div className="navbar-left">
+        <Link to="/genres" className="navbar-logo">
+          Librum
+        </Link>
+      </div>
+      <div className="navbar-right">
+        <XpBadge />
+        <button onClick={handleLogout} className="btn-logout">
+          Sair
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/pages/PhaseCompletedPage.css
+++ b/frontend/src/pages/PhaseCompletedPage.css
@@ -1,0 +1,182 @@
+.phase-completed-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: linear-gradient(145deg, #3A2F80 0%, #4B3FA0 100%);
+  padding: 2rem;
+  box-sizing: border-box;
+}
+
+.phase-completed-card {
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+  padding: 3rem 2.5rem;
+  width: 100%;
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+  box-sizing: border-box;
+}
+
+.phase-completed-badge {
+  background: #F97316;
+  color: white;
+  padding: 0.5rem 1.5rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.phase-completed-badge.error {
+  background: #dc2626;
+}
+
+.phase-completed-title-error {
+  font-size: 1.75rem;
+  font-weight: 800;
+  color: #1f2937;
+  margin: 0;
+}
+
+.phase-completed-text-error {
+  font-size: 1rem;
+  color: #4b5563;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.phase-completed-text-error-sub {
+  font-size: 0.875rem;
+  color: #6b7280;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.phase-completed-xp {
+  font-size: 4rem;
+  font-weight: 800;
+  color: #F97316;
+  line-height: 1;
+}
+
+.phase-completed-levelup {
+  background: #ecfdf5;
+  border: 1px solid #10b981;
+  color: #047857;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 700;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.phase-completed-stats {
+  display: flex;
+  gap: 1rem;
+  width: 100%;
+}
+
+.stat-box {
+  background: #FAF8F5;
+  border: 1px solid #eaeaea;
+  border-radius: 8px;
+  padding: 1.25rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: #1f2937;
+}
+
+.stat-label {
+  font-size: 0.72rem;
+  color: #666;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.phase-completed-progress {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.phase-completed-progress-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #666;
+  font-weight: 600;
+}
+
+.phase-completed-progress-bar {
+  height: 10px;
+  background: #eaeaea;
+  border-radius: 9999px;
+  overflow: hidden;
+}
+
+.phase-completed-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #F97316, #ea580c);
+  border-radius: 9999px;
+  transition: width 1.5s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.phase-completed-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.btn-phase-continue {
+  width: 100%;
+  padding: 1rem;
+  background: linear-gradient(135deg, #ea580c, #F97316);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(249, 115, 22, 0.32);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.btn-phase-continue:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 20px rgba(249, 115, 22, 0.44);
+}
+
+.btn-phase-secondary {
+  width: 100%;
+  padding: 0.875rem;
+  background: transparent;
+  color: #666;
+  border: 1.5px solid #eaeaea;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.btn-phase-secondary:hover {
+  border-color: #666;
+  color: #333;
+}

--- a/frontend/src/pages/PhaseCompletedPage.jsx
+++ b/frontend/src/pages/PhaseCompletedPage.jsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import './PhaseCompletedPage.css';
+
+const PhaseCompletedPage = () => {
+  const { phaseId } = useParams();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const result = location.state;
+
+  if (!result) {
+    navigate(`/quiz/${phaseId}`);
+    return null;
+  }
+
+  const {
+    totalQuestions = 3,
+    correctAnswers = 0,
+    xpEarned = 0,
+    newTotalXp = 0,
+    newLevel = 1,
+    leveledUp = false,
+    nextPhaseId = null,
+    genreSlug = 'aventura',
+    passed = false
+  } = result;
+
+  const xpProgress = newTotalXp % 50;
+  const progressPercentage = (xpProgress / 50) * 100;
+  const hasNextPhase = !!nextPhaseId && passed;
+
+  const handleContinue = () => {
+    if (hasNextPhase) {
+      navigate(`/reading/${nextPhaseId}/1`);
+    } else {
+      navigate(`/genres/${genreSlug || 'aventura'}`);
+    }
+  };
+
+  const handleReRead = () => {
+    navigate(`/reading/${phaseId}/1`);
+  };
+
+  return (
+    <div className="phase-completed-page">
+      <div className="phase-completed-card">
+        {passed ? (
+          <>
+            <div className="phase-completed-badge">FASE {phaseId} CONCLUÍDA!</div>
+            <div className="phase-completed-xp">+{xpEarned} XP</div>
+            
+            {leveledUp && (
+              <div className="phase-completed-levelup">
+                Você subiu para o Nível {newLevel}!
+              </div>
+            )}
+
+            <div className="phase-completed-stats">
+              <div className="stat-box">
+                <span className="stat-value">{correctAnswers}/{totalQuestions}</span>
+                <span className="stat-label">Acertos</span>
+              </div>
+              <div className="stat-box">
+                <span className="stat-value">Nível {newLevel}</span>
+                <span className="stat-label">Nível Atual</span>
+              </div>
+            </div>
+
+            <div className="phase-completed-progress">
+              <div className="phase-completed-progress-header">
+                <span>{xpProgress} / 50 XP</span>
+                <span>Próximo nível: {Math.min(10, newLevel + 1)}</span>
+              </div>
+              <div className="phase-completed-progress-bar">
+                <div
+                  className="phase-completed-progress-fill"
+                  style={{ width: `${progressPercentage}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="phase-completed-actions">
+              <button className="btn-phase-continue" onClick={handleContinue}>
+                {hasNextPhase ? `Ir para a Fase ${nextPhaseId} →` : 'Voltar ao início'}
+              </button>
+              <button
+                className="btn-phase-secondary"
+                onClick={() => navigate(`/genres/${genreSlug || 'aventura'}`)}
+              >
+                Voltar ao início
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <div className="phase-completed-badge error">TENTE NOVAMENTE</div>
+            <h2 className="phase-completed-title-error">Fase Não Concluída</h2>
+            <p className="phase-completed-text-error">
+              Você acertou {correctAnswers} de {totalQuestions} questões. É preciso acertar pelo menos {totalQuestions - 2} questões para concluir a fase.
+            </p>
+            <p className="phase-completed-text-error-sub">
+              Reler os trechos ajudará você a absorver melhor a história e responder corretamente na próxima tentativa.
+            </p>
+            
+            <div className="phase-completed-actions">
+              <button className="btn-phase-continue" onClick={handleReRead}>
+                Reler a Fase
+              </button>
+              <button
+                className="btn-phase-secondary"
+                onClick={() => navigate(`/genres/${genreSlug || 'aventura'}`)}
+              >
+                Voltar ao início
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PhaseCompletedPage;

--- a/frontend/src/pages/PhaseListPage.css
+++ b/frontend/src/pages/PhaseListPage.css
@@ -178,3 +178,17 @@
   color: #666;
   font-weight: 500;
 }
+
+.phase-connector {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 32px;
+  color: #EAEAEA;
+}
+
+.phase-connector-arrow {
+  font-size: 1.4rem;
+  line-height: 1;
+}

--- a/frontend/src/pages/PhaseListPage.jsx
+++ b/frontend/src/pages/PhaseListPage.jsx
@@ -5,7 +5,6 @@ import './PhaseListPage.css';
 import mascote from '../assets/librum-mascote-principal.png';
 import livro from '../assets/books/ilha-do-tesouro.png';
 
-
 export default function PhaseListPage() {
   const { genreId } = useParams();
   const navigate = useNavigate();
@@ -32,7 +31,8 @@ export default function PhaseListPage() {
   const completedCount = phases.filter(p => p.isCompleted).length;
   const totalCount = phases.length;
   const progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
-  const nextPhase = phases.find(p => !p.isCompleted && p.isUnlocked) || phases[0];
+  const nextPhase = phases.find(p => p.isUnlocked && !p.isCompleted);
+  const continueTarget = nextPhase || phases[0];
   const pathHeight = Math.max(phases.length * 80 + 120, 600);
 
   return (
@@ -58,8 +58,8 @@ export default function PhaseListPage() {
           <p className="progress-text">Fase {completedCount} de {totalCount} concluída - {progressPercent}% do livro lido</p>
         </div>
 
-        <button className="btn-continue" onClick={() => handlePhaseClick(nextPhase)}>
-          ▶ Continuar - Fase {nextPhase?.phaseNumber}
+        <button className="btn-continue" onClick={() => handlePhaseClick(continueTarget)}>
+          ▶ Continuar - Fase {continueTarget?.phaseNumber}
         </button>
       </div>
 
@@ -71,17 +71,31 @@ export default function PhaseListPage() {
 
         <div className="phase-path" style={{ height: `${pathHeight}px` }}>
           {phases.map((phase, index) => (
-            <div
-              key={phase.id}
-              className={`phase-node ${phase.isCompleted ? 'completed' : ''} ${phase.isUnlocked && !phase.isCompleted ? 'active' : ''} ${!phase.isUnlocked ? 'locked' : ''}`}
-              onClick={() => handlePhaseClick(phase)}
-              style={{ top: `${index * 80}px`, left: `${(index % 2 === 0 ? 20 : 60)}%` }}
-            >
-              <div className="phase-circle">
-                {phase.isCompleted ? '✓' : phase.isUnlocked ? phase.phaseNumber : '🔒'}
+            <React.Fragment key={phase.id}>
+              <div
+                className={`phase-node ${phase.isCompleted ? 'completed' : ''} ${phase.isUnlocked && !phase.isCompleted ? 'active' : ''} ${!phase.isUnlocked ? 'locked' : ''}`}
+                onClick={() => handlePhaseClick(phase)}
+                style={{ top: `${index * 80}px`, left: `${(index % 2 === 0 ? 20 : 60)}%` }}
+              >
+                <div className="phase-circle">
+                  {phase.isCompleted ? '✓' : phase.isUnlocked ? phase.phaseNumber : '🔒'}
+                </div>
+                <span className="phase-label">Fase {phase.phaseNumber}</span>
               </div>
-              <span className="phase-label">Fase {phase.phaseNumber}</span>
-            </div>
+              {index < phases.length - 1 && (
+                <div
+                  className="phase-connector"
+                  style={{
+                    position: 'absolute',
+                    top: `${index * 80 + 55}px`,
+                    left: `${(index % 2 === 0 ? 20 : 60) + 2.5}%`,
+                    width: '60px'
+                  }}
+                >
+                  <span className="phase-connector-arrow">↓</span>
+                </div>
+              )}
+            </React.Fragment>
           ))}
         </div>
       </div>

--- a/frontend/src/pages/QuizPage.css
+++ b/frontend/src/pages/QuizPage.css
@@ -203,3 +203,41 @@
 .theme-dark .quiz-option-text {
   color: #d1d5db;
 }
+
+.quiz-option.correct {
+  border-color: #16a34a;
+  background: #f0fdf4;
+  color: #15803d;
+}
+
+.quiz-option.incorrect {
+  border-color: #dc2626;
+  background: #fef2f2;
+  color: #b91c1c;
+}
+
+.quiz-explanation {
+  margin-top: 12px;
+  padding: 14px 16px;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.quiz-explanation.correct {
+  background: #f0fdf4;
+  border: 1px solid #86efac;
+  color: #166534;
+}
+
+.quiz-explanation.incorrect {
+  background: #fef2f2;
+  border: 1px solid #fca5a5;
+  color: #991b1b;
+}
+
+.quiz-explanation-label {
+  font-weight: 700;
+  margin-bottom: 4px;
+}

--- a/frontend/src/pages/QuizPage.jsx
+++ b/frontend/src/pages/QuizPage.jsx
@@ -6,7 +6,6 @@ import './QuizPage.css';
 const QuizPage = () => {
   const { phaseId } = useParams();
   const navigate = useNavigate();
-  const [questions, setQuestions] = null;
   const [loading, setLoading] = useState(true);
   const [answers, setAnswers] = useState([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
@@ -48,33 +47,31 @@ const QuizPage = () => {
   const handleConfirm = () => {
     if (!selectedOption) return;
 
-    const isCorrectMock = selectedOption === 'A' || selectedOption === 'B';
-    setFeedback(isCorrectMock ? 'correct' : 'incorrect');
+    const isCorrect = selectedOption === currentQuestion.correctOption;
+    setFeedback(isCorrect ? 'correct' : 'incorrect');
 
     const newAnswer = {
       questionId: currentQuestion.id,
       selectedOption: selectedOption
     };
+    setAnswers([...answers, newAnswer]);
+  };
 
-    const newAnswersList = [...answers, newAnswer];
-    setAnswers(newAnswersList);
-
-    setTimeout(() => {
-      if (currentQuestionIndex < questionsData.length - 1) {
-        setCurrentQuestionIndex(currentQuestionIndex + 1);
-        setSelectedOption('');
-        setFeedback(null);
-      } else {
-        submitFinalQuiz(newAnswersList);
-      }
-    }, 1500);
+  const handleNext = () => {
+    if (currentQuestionIndex < questionsData.length - 1) {
+      setCurrentQuestionIndex(currentQuestionIndex + 1);
+      setSelectedOption('');
+      setFeedback(null);
+    } else {
+      submitFinalQuiz(answers);
+    }
   };
 
   const submitFinalQuiz = async (finalAnswers) => {
     try {
       setSubmitting(true);
       const result = await QuizService.submitQuiz(phaseId, finalAnswers);
-      navigate(`/quiz/${phaseId}/resultado`, { state: result });
+      navigate(`/quiz/${phaseId}/fase-concluida`, { state: result });
     } catch (error) {
       console.error("Erro ao enviar quiz:", error);
       alert("Houve um erro ao enviar suas respostas.");
@@ -91,32 +88,64 @@ const QuizPage = () => {
           <h3 className="quiz-question-text">{currentQuestion.questionText}</h3>
 
           <div className="quiz-options">
-            {['A', 'B', 'C', 'D'].map((opt) => (
-              <label
-                key={opt}
-                className={`quiz-option ${selectedOption === opt ? 'selected' : ''} ${feedback && selectedOption === opt ? feedback : ''}`}
-              >
-                <input
-                  type="radio"
-                  name="quiz-option"
-                  value={opt}
-                  checked={selectedOption === opt}
-                  onChange={handleOptionChange}
-                  disabled={feedback !== null}
-                />
-                <span className="quiz-option-letter">{opt}</span>
-                <span className="quiz-option-text">{currentQuestion[`option${opt}`]}</span>
-              </label>
-            ))}
+            {['A', 'B', 'C', 'D'].map((opt) => {
+              const isSelected = selectedOption === opt;
+              const isCorrect = currentQuestion.correctOption === opt;
+              let optionClass = '';
+              if (isSelected) optionClass += ' selected';
+              if (feedback) {
+                if (isCorrect) {
+                  optionClass += ' correct';
+                } else if (isSelected) {
+                  optionClass += ' incorrect';
+                }
+              }
+              return (
+                <label
+                  key={opt}
+                  className={`quiz-option${optionClass}`}
+                >
+                  <input
+                    type="radio"
+                    name="quiz-option"
+                    value={opt}
+                    checked={isSelected}
+                    onChange={handleOptionChange}
+                    disabled={feedback !== null}
+                  />
+                  <span className="quiz-option-letter">{opt}</span>
+                  <span className="quiz-option-text">{currentQuestion[`option${opt}`]}</span>
+                </label>
+              );
+            })}
           </div>
 
-          <button
-            className="quiz-confirm-btn"
-            onClick={handleConfirm}
-            disabled={!selectedOption || feedback !== null || submitting}
-          >
-            {submitting ? 'Enviando...' : 'Confirmar'}
-          </button>
+          {feedback && (
+            <div className={`quiz-explanation ${feedback}`}>
+              <div className="quiz-explanation-label">
+                {feedback === 'correct' ? 'Correto!' : 'Errado.'}
+              </div>
+              <p>{currentQuestion.explanation || 'Sem explicação disponível.'}</p>
+            </div>
+          )}
+
+          {feedback === null ? (
+            <button
+              className="quiz-confirm-btn"
+              onClick={handleConfirm}
+              disabled={!selectedOption || submitting}
+            >
+              {submitting ? 'Enviando...' : 'Confirmar'}
+            </button>
+          ) : (
+            <button
+              className="quiz-confirm-btn"
+              onClick={handleNext}
+              disabled={submitting}
+            >
+              {currentQuestionIndex < questionsData.length - 1 ? 'Próxima questão →' : 'Ver resultado →'}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/ReadingPage.jsx
+++ b/frontend/src/pages/ReadingPage.jsx
@@ -78,10 +78,10 @@ export default function ReadingPage() {
     <div className="reading-container">
       <header className="reading-header">
         <div className="header-left">
-          <button onClick={() => navigate('/genres/aventura')} className="btn-logo">
+          <button onClick={() => navigate(`/genres/${content?.genreSlug || 'aventura'}`)} className="btn-logo">
             <img src={logoLivro} alt="Logo Librum" style={{ width: '56px', height: '56px', objectFit: 'contain', padding: '0px' }} />
           </button>
-          <span className="breadcrumb">← <span className="highlight">A Ilha do Tesouro</span> · Fase {phaseId}</span>
+          <span className="breadcrumb">← <span className="highlight">{content?.bookTitle || 'A Ilha do Tesouro'}</span> · Fase {phaseId}</span>
         </div>
         <div className="header-center">
           Trecho {segmentNumber} de {content.totalSegments}
@@ -139,7 +139,9 @@ export default function ReadingPage() {
 
           <div className="content-footer">
             <span>~{content.estimatedMinutes} min · Trecho {segmentNumber}/{content.totalSegments}</span>
-            <button className="btn-next" onClick={handleNext}>Ir ao quiz →</button>
+            <button className="btn-next" onClick={handleNext}>
+              {Number(segmentNumber) >= content.totalSegments ? 'Ir ao quiz →' : 'Próximo trecho →'}
+            </button>
           </div>
         </main>
 

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -6,7 +6,9 @@ import PhaseListPage from '../pages/PhaseListPage';
 import ReadingPage from '../pages/ReadingPage';
 import QuizPage from '../pages/QuizPage';
 import QuizResultPage from '../pages/QuizResultPage';
+import PhaseCompletedPage from '../pages/PhaseCompletedPage';
 import PrivateRoute from "./PrivateRoute";
+import Layout from '../components/Layout';
 
 export const AppRoutes = () => {
   return (
@@ -19,7 +21,9 @@ export const AppRoutes = () => {
           path="/genres"
           element={
             <PrivateRoute>
-              <GenresPage />
+              <Layout>
+                <GenresPage />
+              </Layout>
             </PrivateRoute>
           }
         />
@@ -52,10 +56,21 @@ export const AppRoutes = () => {
         />
 
         <Route
+          path="/quiz/:phaseId/fase-concluida"
+          element={
+            <PrivateRoute>
+              <PhaseCompletedPage />
+            </PrivateRoute>
+          }
+        />
+
+        <Route
           path="/genres/:genreId"
           element={
             <PrivateRoute>
-              <PhaseListPage />
+              <Layout>
+                <PhaseListPage />
+              </Layout>
             </PrivateRoute>
           }
         />

--- a/frontend/src/services/QuizService.js
+++ b/frontend/src/services/QuizService.js
@@ -64,15 +64,18 @@ export const QuizService = {
       return await response.json();
     } catch (error) {
       console.error(error);
-      const correctAnswers = Math.floor(Math.random() * 4);
+      const totalQuestions = answers.length || 3;
+      const correctAnswers = totalQuestions;
       const xpEarned = correctAnswers * 5;
       return {
-        totalQuestions: 3,
+        totalQuestions: totalQuestions,
         correctAnswers: correctAnswers,
         xpEarned: xpEarned,
         newTotalXp: 45 + xpEarned,
         newLevel: 1 + Math.floor((45 + xpEarned) / 50),
-        leveledUp: (45 + xpEarned) >= 50
+        leveledUp: (45 + xpEarned) >= 50,
+        nextPhaseId: parseInt(phaseId) + 1,
+        passed: true
       };
     }
   }


### PR DESCRIPTION
## Descrição

Implementação das tarefas de frontend da Sprint 3 (Parte 2): correção dos bugs críticos do QuizPage e ReadingPage, integração do layout global com Navbar, trilha visual de fases e nova tela pós-quiz (US09).

Closes #111 
Closes #112 
Closes #113 

---

## Tipo de Mudança

- [x] Nova funcionalidade
- [x] Correção de bug

---

## Como Testar

1. Rodar `npm run dev` na pasta `frontend` e acessar `http://localhost:5173`
2. Fazer login e verificar que a Navbar com botão "Sair" e XpBadge aparece em `/genres` e `/genres/aventura`
3. Acessar `/reading/1/1` e verificar que o botão do rodapé exibe "Próximo trecho →" nos segmentos intermediários e "Ir ao quiz →" no último segmento
4. Acessar `/reading/1/1` e clicar em "← Librum" no breadcrumb — deve navegar para `/genres/aventura` (dinâmico via `genreSlug`)
5. Acessar `/genres/aventura` e verificar que as fases estão conectadas por setas `↓` na trilha visual
6. Verificar que o botão "Continuar" aponta para a Fase 1 em contas novas (sem progresso)
7. Acessar `/quiz/1`, responder uma questão e clicar "Confirmar" — deve exibir "Correto!" (verde) ou "Errado." (vermelho) com o texto de explicação abaixo
8. Concluir o quiz com aprovação (≤ 2 erros) — deve redirecionar para a `PhaseCompletedPage` com badge "FASE X CONCLUÍDA!", XP ganho e botão "Ir para a Fase X+1 →"
9. Concluir o quiz com reprovação (> 2 erros) — deve exibir mensagem de reprovação e botão "Reler a Fase" sem botão de próxima fase

**Resultado esperado:** todos os fluxos acima funcionam sem erros no console, sem crash no QuizPage e com navegação dinâmica correta.

---

## Checklist

- [x] Código compila e executa sem erros
- [ ] Testes adicionados/atualizados e passando
- [x] Padrões de código seguidos (lint/formatação)
- [x] Commits seguem Conventional Commits
- [ ] Branch atualizada com `develop`
