### PR TITLE
Feat/atualizacao backend

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -94,6 +94,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/librum/dto/PhaseSegmentResponse.java
+++ b/backend/src/main/java/com/librum/dto/PhaseSegmentResponse.java
@@ -9,5 +9,6 @@ public record PhaseSegmentResponse(
         int phaseNumber,
         String bookTitle,
         String bookAuthor,
-        String genreName
+        String genreName,
+        String genreSlug
 ) {}

--- a/backend/src/main/java/com/librum/dto/QuizQuestionResponse.java
+++ b/backend/src/main/java/com/librum/dto/QuizQuestionResponse.java
@@ -7,5 +7,7 @@ public record QuizQuestionResponse(
         String optionA,
         String optionB,
         String optionC,
-        String optionD
+        String optionD,
+        String correctOption,
+        String explanation
 ) {}

--- a/backend/src/main/java/com/librum/dto/QuizResultResponse.java
+++ b/backend/src/main/java/com/librum/dto/QuizResultResponse.java
@@ -6,5 +6,7 @@ public record QuizResultResponse(
         int xpEarned,
         int newTotalXp,
         int newLevel,
-        boolean leveledUp
+        boolean leveledUp,
+        Long nextPhaseId,
+        boolean passed
 ) {}

--- a/backend/src/main/java/com/librum/model/QuizQuestion.java
+++ b/backend/src/main/java/com/librum/model/QuizQuestion.java
@@ -35,6 +35,9 @@ public class QuizQuestion {
     @Column(name = "order_index", nullable = false)
     private int orderIndex;
 
+    @Column(name = "explanation", columnDefinition = "TEXT")
+    private String explanation;
+
     public QuizQuestion() {}
 
     public Long getId() { return id; }
@@ -55,4 +58,6 @@ public class QuizQuestion {
     public void setCorrectOption(char correctOption) { this.correctOption = correctOption; }
     public int getOrderIndex() { return orderIndex; }
     public void setOrderIndex(int orderIndex) { this.orderIndex = orderIndex; }
+    public String getExplanation() { return explanation; }
+    public void setExplanation(String explanation) { this.explanation = explanation; }
 }

--- a/backend/src/main/java/com/librum/model/UserProgress.java
+++ b/backend/src/main/java/com/librum/model/UserProgress.java
@@ -27,6 +27,9 @@ public class UserProgress {
     @Column(name = "is_completed", nullable = false)
     private boolean isCompleted = false;
 
+    @Column(name = "quiz_completed", nullable = false)
+    private boolean quizCompleted = false;
+
     @Column(name = "completed_at")
     private LocalDateTime completedAt;
 
@@ -42,6 +45,8 @@ public class UserProgress {
     public void setLastSegmentRead(int lastSegmentRead) { this.lastSegmentRead = lastSegmentRead; }
     public boolean isCompleted() { return isCompleted; }
     public void setCompleted(boolean completed) { isCompleted = completed; }
+    public boolean isQuizCompleted() { return quizCompleted; }
+    public void setQuizCompleted(boolean quizCompleted) { this.quizCompleted = quizCompleted; }
     public LocalDateTime getCompletedAt() { return completedAt; }
     public void setCompletedAt(LocalDateTime completedAt) { this.completedAt = completedAt; }
 }

--- a/backend/src/main/java/com/librum/repository/PhaseRepository.java
+++ b/backend/src/main/java/com/librum/repository/PhaseRepository.java
@@ -4,7 +4,9 @@ import com.librum.model.Phase;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PhaseRepository extends JpaRepository<Phase, Long> {
     List<Phase> findByBookIdOrderByPhaseNumber(Long bookId);
+    Optional<Phase> findByBookIdAndPhaseNumber(Long bookId, int phaseNumber);
 }

--- a/backend/src/main/java/com/librum/repository/UserProgressRepository.java
+++ b/backend/src/main/java/com/librum/repository/UserProgressRepository.java
@@ -9,4 +9,5 @@ import java.util.UUID;
 public interface UserProgressRepository extends JpaRepository<UserProgress, Long> {
     Optional<UserProgress> findByUserIdAndPhaseId(UUID userId, Long phaseId);
     boolean existsByUserIdAndPhaseIdAndIsCompletedTrue(UUID userId, Long phaseId);
+    boolean existsByUserIdAndPhaseIdAndQuizCompletedTrue(UUID userId, Long phaseId);
 }

--- a/backend/src/main/java/com/librum/service/QuizService.java
+++ b/backend/src/main/java/com/librum/service/QuizService.java
@@ -49,7 +49,9 @@ public class QuizService {
                     q.getOptionA(),
                     q.getOptionB(),
                     q.getOptionC(),
-                    q.getOptionD()
+                    q.getOptionD(),
+                    String.valueOf(q.getCorrectOption()),
+                    q.getExplanation()
                 )
             )
             .toList();
@@ -106,7 +108,9 @@ public class QuizService {
             xpEarned,
             updatedUser.getXp(),
             updatedUser.getLevel(),
-            updatedUser.getLevel() > oldLevel
+            updatedUser.getLevel() > oldLevel,
+            null,
+            false
         );
     }
 }

--- a/backend/src/main/java/com/librum/service/QuizService.java
+++ b/backend/src/main/java/com/librum/service/QuizService.java
@@ -3,11 +3,16 @@ package com.librum.service;
 import com.librum.dto.QuizQuestionResponse;
 import com.librum.dto.QuizResultRequest;
 import com.librum.dto.QuizResultResponse;
+import com.librum.model.Phase;
 import com.librum.model.QuizQuestion;
 import com.librum.model.User;
+import com.librum.model.UserProgress;
+import com.librum.repository.PhaseRepository;
 import com.librum.repository.QuizQuestionRepository;
+import com.librum.repository.UserProgressRepository;
 import com.librum.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -20,15 +25,21 @@ public class QuizService {
     private final QuizQuestionRepository quizQuestionRepository;
     private final XpService xpService;
     private final UserRepository userRepository;
+    private final UserProgressRepository userProgressRepository;
+    private final PhaseRepository phaseRepository;
 
     public QuizService(
         QuizQuestionRepository quizQuestionRepository,
         XpService xpService,
-        UserRepository userRepository
+        UserRepository userRepository,
+        UserProgressRepository userProgressRepository,
+        PhaseRepository phaseRepository
     ) {
         this.quizQuestionRepository = quizQuestionRepository;
         this.xpService = xpService;
         this.userRepository = userRepository;
+        this.userProgressRepository = userProgressRepository;
+        this.phaseRepository = phaseRepository;
     }
 
     public List<QuizQuestionResponse> getQuestions(Long phaseId) {
@@ -102,6 +113,32 @@ public class QuizService {
         int xpEarned = correctAnswers * 5;
         User updatedUser = xpService.addXp(userId, xpEarned);
 
+        boolean passed = (questions.size() - correctAnswers) <= 2;
+        Long nextPhaseId = null;
+
+        if (passed) {
+            Phase phase = questions.get(0).getPhase();
+            UserProgress progress = userProgressRepository
+                .findByUserIdAndPhaseId(userId, phaseId)
+                .orElseGet(() -> {
+                    UserProgress np = new UserProgress();
+                    np.setUser(user);
+                    np.setPhase(phase);
+                    return np;
+                });
+            progress.setQuizCompleted(true);
+            progress.setCompleted(true);
+            if (progress.getCompletedAt() == null) {
+                progress.setCompletedAt(LocalDateTime.now());
+            }
+            userProgressRepository.save(progress);
+
+            nextPhaseId = phaseRepository
+                .findByBookIdAndPhaseNumber(phase.getBook().getId(), phase.getPhaseNumber() + 1)
+                .map(Phase::getId)
+                .orElse(null);
+        }
+
         return new QuizResultResponse(
             questions.size(),
             correctAnswers,
@@ -109,8 +146,8 @@ public class QuizService {
             updatedUser.getXp(),
             updatedUser.getLevel(),
             updatedUser.getLevel() > oldLevel,
-            null,
-            false
+            nextPhaseId,
+            passed
         );
     }
 }

--- a/backend/src/main/java/com/librum/service/ReadingService.java
+++ b/backend/src/main/java/com/librum/service/ReadingService.java
@@ -58,7 +58,8 @@ public class ReadingService {
                 phase.getPhaseNumber(),
                 book.getTitle(),
                 book.getAuthor(),
-                book.getGenre().getName()
+                book.getGenre().getName(),
+                book.getGenre().getSlug()
         );
     }
 

--- a/backend/src/main/java/com/librum/service/ReadingService.java
+++ b/backend/src/main/java/com/librum/service/ReadingService.java
@@ -103,6 +103,6 @@ public class ReadingService {
             return false;
         }
 
-        return userProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, previousPhase.getId());
+        return userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, previousPhase.getId());
     }
 }

--- a/backend/src/main/resources/db/migration/V6__schema_explanation_quiz_completed.sql
+++ b/backend/src/main/resources/db/migration/V6__schema_explanation_quiz_completed.sql
@@ -1,0 +1,3 @@
+ALTER TABLE quiz_questions ADD COLUMN explanation TEXT;
+
+ALTER TABLE user_progress ADD COLUMN quiz_completed BOOLEAN NOT NULL DEFAULT FALSE;

--- a/backend/src/main/resources/db/migration/V7__seed_phases_5_6_7.sql
+++ b/backend/src/main/resources/db/migration/V7__seed_phases_5_6_7.sql
@@ -1,0 +1,110 @@
+-- Fase 5: O Cerco ao Forte
+INSERT INTO phases (book_id, phase_number, title)
+SELECT id, 5, 'Fase 5: O Cerco ao Forte' FROM books WHERE title = 'A Ilha do Tesouro';
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 1,
+'O forte de madeira era mais seguro do que esperávamos. Construído anos antes por um grupo de buscadores de ouro, tinha paredes grossas de troncos e uma clareira ao redor que impediria qualquer abordagem surpresa.
+
+Passamos a noite organizando as defesas. O capitão Smollett distribuiu as posições com precisão militar, colocando dois homens em cada janela e mantendo uma reserva no centro. A névoa da madrugada tornava tudo mais silencioso e tenso.
+
+Ao amanhecer, avistamos as primeiras sombras se movendo entre as árvores. Os piratas haviam cercado o forte completamente. Eu contei pelo menos quinze deles, todos armados.',
+3
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 5;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 2,
+'O ataque começou com um grito de guerra de Silver ordenando o avanço. Uma chuva de balas varreu as paredes de madeira. O capitão Smollett foi atingido no ombro mas continuou de pé, gritando ordens com voz firme.
+
+Quando os piratas tentaram escalar as paredes, os repelimos com coronhadas e baionetas. A batalha durou menos de vinte minutos mas pareceu uma eternidade. No fim, seis piratas jaziam na clareira. Nós havíamos perdido dois homens.
+
+Ficamos em silêncio depois que os tiros cessaram. O doutor Livesey curou os feridos enquanto o capitão fazia a contagem: restavam cinco homens leais contra os cerca de doze piratas sobreviventes.',
+4
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 5;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 3,
+'Na manhã seguinte, Silver apareceu na beira da floresta com uma bandeira branca improvisada com um lenço. Caminhou devagar até a entrada do forte, sua muleta afundando na terra mole.
+
+Disse ao capitão Smollett que era um homem razoável e ofereceu uma proposta: entregassem o mapa e em troca todos poderiam voltar para casa em segurança. Tinha aquele sorriso que eu havia aprendido a não confiar.
+
+O capitão o escutou sem piscar. Respondeu com calma que sair daquele forte seria a última coisa que fariam e que podiam tentar tomá-lo quando quisessem. Silver partiu sem seu sorriso.',
+3
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 5;
+
+-- Fase 6: Jim e o Hispaniola
+INSERT INTO phases (book_id, phase_number, title)
+SELECT id, 6, 'Fase 6: Jim e o Hispaniola' FROM books WHERE title = 'A Ilha do Tesouro';
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 1,
+'Naquela noite, enquanto os outros dormiam, tomei a decisão mais temerária da minha vida. Saí pelo postigo traseiro do forte, descendo cuidadosamente pela madeira escorregadia.
+
+Ben Gunn havia me mostrado, dias antes, onde escondia sua corácula, uma pequena embarcação de couro construída com as próprias mãos. Era frágil e difícil de manobrar, mas suficiente para chegar até o Hispaniola, que balançava ancorado na baía.
+
+Remei silenciosamente pela água escura, orientado apenas pelas luzes distantes do navio. Sentia que estava fazendo algo importante, ainda que não soubesse exatamente o que esperava encontrar a bordo.',
+3
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 6;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 2,
+'A bordo do Hispaniola, encontrei Israel Hands, o timoneiro, completamente bêbado. O outro pirata estava morto, vítima de uma briga entre os dois.
+
+Hands e eu chegamos a um acordo provisório: ele me ensinaria a manobrar o navio em troca de comida e vinho. Passei horas aprendendo a controlar o leme enquanto ele me observava com olhos calculistas.
+
+Então, num momento de descuido meu, ele agarrou uma faca ensanguentada e avançou. Subi pelo mastro como um macaco, mas ele me acertou o ombro com a lâmina. No momento em que tentou subir atrás de mim, disparei minha pistola. Israel Hands caiu no mar para nunca mais aparecer.',
+4
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 6;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 3,
+'Consegui ancorar o Hispaniola numa pequena enseada ao norte, escondida pela vegetação densa. Os piratas não poderiam mais usar o navio para fugir.
+
+Quando voltei ao forte pela madrugada, encontrei a porta escancarada e trevas absolutas. Acendi um fósforo e vi rostos desconhecidos. Eram piratas, e eu estava preso.
+
+Long John Silver surgiu das sombras e impediu os outros de me atacar. Disse com voz tranquila que aquele rapaz ficaria com ele. Eu era agora um prisioneiro, mas sentia que Silver, de alguma forma inexplicável, estava tentando me proteger dos seus próprios homens.',
+4
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 6;
+
+-- Fase 7: O Fim da Aventura
+INSERT INTO phases (book_id, phase_number, title)
+SELECT id, 7, 'Fase 7: O Fim da Aventura' FROM books WHERE title = 'A Ilha do Tesouro';
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 1,
+'O doutor Livesey chegou ao acampamento dos piratas no dia seguinte com uma oferta surpreendente: ele entregaria o mapa original em troca da minha liberdade e da vida de Silver. Silver aceitou sem hesitar.
+
+Quando vi o doutor me olhar com um sorriso calmo antes de ir embora, compreendi que havia algo que eu não sabia. O mapa já não importava da maneira que Silver supunha.
+
+A marcha para o interior da ilha começou ao amanhecer. Silver comandava com sua autoridade habitual, mas eu podia ver nos rostos dos outros piratas uma desconfiança crescente. Eles sabiam que Silver havia negociado sua própria pele às custas deles.',
+3
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 7;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 2,
+'Quando chegamos ao local marcado no mapa, os piratas escavaram freneticamente sob o sol do meio-dia. A terra era solta, o que indicava que havia sido escavada antes.
+
+Então um dos piratas gritou de dentro da vala que o buraco estava vazio. O silêncio que se seguiu foi mais assustador do que qualquer batalha.
+
+Os piratas olharam para Silver com raiva pura, as espingardas sendo levantadas. Mas antes que pudessem agir, tiros ecoaram pela floresta. O doutor Livesey, o esquire Trelawney e Ben Gunn caíram sobre os piratas pelo flanco. A batalha foi breve. Os piratas restantes fugiram ou se renderam.',
+4
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 7;
+
+INSERT INTO phase_segments (phase_id, segment_number, content, estimated_minutes)
+SELECT p.id, 3,
+'Ben Gunn havia encontrado o tesouro meses antes da nossa chegada e o havia carregado sozinho, peça por peça, para sua caverna nas colinas do norte. Era por isso que o doutor havia entregado o mapa sem relutância.
+
+Levamos três dias para carregar as barras de ouro e as moedas para o Hispaniola. Era uma quantidade que nenhum de nós havia imaginado, suficiente para mudar o destino de cada um de nós para sempre.
+
+Quando partimos da Ilha do Tesouro, Silver pediu sua parte e recebeu uma bolsa modesta. Numa das noites da viagem, ele simplesmente desapareceu com ela. Ninguém foi atrás dele. Chegamos à Inglaterra ricos e com histórias que guardaríamos pelo resto de nossas vidas.',
+5
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 7;

--- a/backend/src/main/resources/db/migration/V8__seed_quiz_phases_5_6_7_and_explanations.sql
+++ b/backend/src/main/resources/db/migration/V8__seed_quiz_phases_5_6_7_and_explanations.sql
@@ -1,0 +1,208 @@
+-- Atualiza as questões existentes (fases 1 a 4) com o texto de explicação introduzido em V6.
+
+UPDATE quiz_questions
+SET explanation = 'Billy Bones pagava a Jim uma moeda de prata por mês para ficar de olho em um marinheiro de uma perna só, que viria a ser o famoso Long John Silver.'
+WHERE question_text = 'O que o velho marinheiro pediu a Jim em troca de uma moeda de prata por mês?';
+
+UPDATE quiz_questions
+SET explanation = 'O papel negro era o sinal de morte usado entre piratas. Pew o entregou ao capitão Billy Bones, que morreu de choque logo em seguida.'
+WHERE question_text = 'O que o homem cego Pew colocou na mão do capitão?';
+
+UPDATE quiz_questions
+SET explanation = 'No fundo do baú havia um mapa com três cruzes vermelhas apontando o tesouro do Capitão Flint, ponto de partida de toda a aventura.'
+WHERE question_text = 'O que Jim e sua mãe encontraram no fundo do baú do capitão?';
+
+UPDATE quiz_questions
+SET explanation = 'O capitão Billy Bones teve um ataque fulminante logo após receber o papel negro de Pew, morrendo naquela mesma noite.'
+WHERE question_text = 'Como o capitão morreu naquela noite?';
+
+UPDATE quiz_questions
+SET explanation = 'Long John Silver se locomovia com uma muleta de madeira, pois havia perdido a perna em batalha. Ele também tinha um papagaio no ombro que gritava "Peças de oito!".'
+WHERE question_text = 'Como Long John Silver se locomovia a bordo do Hispaniola?';
+
+UPDATE quiz_questions
+SET explanation = 'Jim havia entrado no barril para pegar uma maçã e adormecido. Acordou quando Silver e outros piratas começaram a conversar ao lado, sem saber que Jim estava escutando tudo.'
+WHERE question_text = 'Onde Jim estava escondido quando ouviu o plano de Silver?';
+
+UPDATE quiz_questions
+SET explanation = 'Silver planejava esperar o tesouro ser encontrado e então eliminar todos os homens leais ao capitão, tomando o navio e o tesouro para si.'
+WHERE question_text = 'O que Silver planejava fazer quando o tesouro fosse encontrado?';
+
+UPDATE quiz_questions
+SET explanation = 'Jim contou o plano de Silver ao doutor Livesey e ao capitão Smollett. Eles decidiram aguardar a chegada à ilha para agir, pois os piratas eram maioria a bordo.'
+WHERE question_text = 'A quem Jim avisou sobre a traição de Silver?';
+
+UPDATE quiz_questions
+SET explanation = 'Ben Gunn havia sido abandonado na ilha há três anos pelos seus antigos companheiros piratas, como castigo. Sobreviveu sozinho todo esse tempo.'
+WHERE question_text = 'Quem era Ben Gunn?';
+
+UPDATE quiz_questions
+SET explanation = 'Jim cortou as amarras do Hispaniola para impedir os piratas de usarem o navio para fugir ou se reabastecer, deixando-o à deriva na baía.'
+WHERE question_text = 'O que Jim fez com o Hispaniola durante a noite?';
+
+UPDATE quiz_questions
+SET explanation = 'Silver havia ido ao forte com uma bandeira branca para negociar, propondo que os homens leais entregassem o mapa em troca de salvo-conduto. O capitão recusou e Silver voltou furioso.'
+WHERE question_text = 'O que aconteceu quando Silver foi negociar com o capitão Smollett?';
+
+UPDATE quiz_questions
+SET explanation = 'Ben Gunn havia encontrado e removido o tesouro meses antes. Por isso o doutor entregou o mapa sem medo, sabendo que lá não havia mais nada.'
+WHERE question_text = 'O que os piratas encontraram no local marcado no mapa?';
+
+UPDATE quiz_questions
+SET explanation = 'Ben Gunn havia transferido o tesouro para sua caverna meses antes. O doutor Livesey sabia disso e por isso entregou o mapa a Silver sem hesitar.'
+WHERE question_text = 'Quem havia movido o tesouro antes dos piratas chegarem ao local?';
+
+UPDATE quiz_questions
+SET explanation = 'Silver aproveitou a confusão para desaparecer com uma bolsa de ouro durante a viagem de volta. Ninguém foi atrás dele, e a maioria considerou uma saída justa para alguém tão escorregadio.'
+WHERE question_text = 'O que aconteceu com Long John Silver ao final da história?';
+
+UPDATE quiz_questions
+SET explanation = 'Os três piratas preferiram ficar na ilha a enfrentar a justiça na Inglaterra, onde seriam provavelmente enforcados por pirataria.'
+WHERE question_text = 'O que os personagens leais fizeram com os três piratas restantes?';
+
+-- Fase 5: O Cerco ao Forte (4 questões)
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Quem foi atingido durante o ataque pirata ao forte?',
+    'Jim Hawkins',
+    'O doutor Livesey',
+    'O capitão Smollett',
+    'Ben Gunn',
+    'C', 1,
+    'O capitão Smollett foi atingido no ombro durante o ataque, mas continuou de pé comandando a defesa do forte.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 5;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Quantos piratas morreram no ataque ao forte?',
+    'Dois',
+    'Quatro',
+    'Seis',
+    'Doze',
+    'C', 2,
+    'Seis piratas jaziam na clareira após a batalha. Os homens leais perderam dois companheiros, mas conseguiram repelir o ataque.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 5;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que Silver propôs ao vir com a bandeira branca?',
+    'Uma trégua de 24 horas',
+    'Que entregassem o mapa em troca de segurança',
+    'A entrega dos homens leais',
+    'Uma divisão igual do tesouro',
+    'B', 3,
+    'Silver propôs que entregassem o mapa e, em troca, todos poderiam ir para casa em segurança. O capitão Smollett recusou a proposta.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 5;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que a clareira ao redor do forte impediria?',
+    'Que os piratas escavassem',
+    'Qualquer abordagem surpresa',
+    'Que Ben Gunn chegasse ao forte',
+    'Que o vento apagasse as tochas',
+    'B', 4,
+    'A clareira ao redor eliminava qualquer possibilidade de aproximação sem ser visto, tornando o forte difícil de cercar sem ser detectado.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 5;
+
+-- Fase 6: Jim e o Hispaniola (4 questões)
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que Jim usou para chegar ao Hispaniola à noite?',
+    'Uma tábua de madeira',
+    'A lancha dos piratas',
+    'A corácula de Ben Gunn',
+    'Um barco de pesca',
+    'C', 1,
+    'Jim usou a corácula de Ben Gunn, uma pequena embarcação de couro artesanal que Ben havia construído com as próprias mãos durante seus três anos na ilha.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 6;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Quem era o único pirata a bordo do Hispaniola quando Jim chegou?',
+    'Long John Silver',
+    'Dick Johnson',
+    'Israel Hands, o timoneiro',
+    'O capitão dos piratas',
+    'C', 2,
+    'Israel Hands era o timoneiro e o único sobrevivente de uma briga entre dois piratas que haviam ficado a bordo para vigiar o navio.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 6;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que aconteceu com Israel Hands?',
+    'Fez um acordo e fugiu',
+    'Caiu ao mar após ser atingido por Jim',
+    'Se rendeu ao capitão Smollett',
+    'Ficou aprisionado no porão',
+    'B', 3,
+    'Após tentar atacar Jim com uma faca e acertá-lo no ombro, Hands foi atingido pela pistola de Jim quando tentava subir o mastro, caindo ao mar.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 6;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Em que condição Jim voltou ao forte?',
+    'Como herói com o navio controlado',
+    'Ferido mas livre',
+    'Como prisioneiro dos piratas',
+    'Com reforços de Ben Gunn',
+    'C', 4,
+    'Jim encontrou o forte ocupado pelos piratas e foi capturado. Silver interveio para protegê-lo de ser atacado pelos outros piratas que queriam vingança.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 6;
+
+-- Fase 7: O Fim da Aventura (4 questões)
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que o doutor Livesey ofereceu em troca da liberdade de Jim?',
+    'Ouro para os piratas',
+    'O mapa do tesouro',
+    'A liberdade de Silver em separado',
+    'Uma passagem para a Inglaterra',
+    'B', 1,
+    'O doutor entregou o mapa original do Capitão Flint. Ele podia fazer isso sem risco porque Ben Gunn já havia removido o tesouro meses antes, de modo que o mapa não levaria a mais nada.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 7;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Por que o buraco no local marcado no mapa estava vazio?',
+    'Silver havia escondido o tesouro em outro lugar',
+    'O tesouro nunca existiu',
+    'Ben Gunn havia movido o tesouro para sua caverna',
+    'Os piratas já tinham escavado antes',
+    'C', 2,
+    'Ben Gunn havia encontrado o tesouro meses antes da expedição chegar e carregou tudo sozinho para sua caverna secreta nas colinas do norte da ilha.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 7;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Quanto tempo levou para carregar o tesouro para o Hispaniola?',
+    'Um dia',
+    'Dois dias',
+    'Três dias',
+    'Uma semana',
+    'C', 3,
+    'Foram necessários três dias de trabalho exaustivo para transportar todas as barras de ouro, moedas de dezenas de países e joias da caverna de Ben Gunn até o Hispaniola.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 7;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que aconteceu com Long John Silver ao final da história?',
+    'Foi preso ao chegar na Inglaterra',
+    'Morreu durante a batalha final',
+    'Recebeu parte do tesouro e desapareceu durante a viagem',
+    'Foi abandonado na ilha',
+    'C', 4,
+    'Silver recebeu uma bolsa modesta de ouro como acordo e, numa das noites da viagem de volta para a Inglaterra, simplesmente sumiu. Ninguém foi atrás dele.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 7;

--- a/backend/src/test/java/com/librum/BackendApplicationTests.java
+++ b/backend/src/test/java/com/librum/BackendApplicationTests.java
@@ -2,8 +2,10 @@ package com.librum;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class BackendApplicationTests {
 
     @Test

--- a/backend/src/test/java/com/librum/controller/QuizControllerIntegrationTest.java
+++ b/backend/src/test/java/com/librum/controller/QuizControllerIntegrationTest.java
@@ -56,7 +56,7 @@ public class QuizControllerIntegrationTest {
 
     @Test
     @WithMockUser(username = "giuliano@librum.com")
-    void getQuiz_comAutenticacao_retornaListaSemCorrectOption() throws Exception {
+    void getQuiz_comAutenticacao_retornaListaComCorrectOptionEExplanation() throws Exception {
         UUID userId = UUID.randomUUID();
         User user = new User();
         user.setId(userId);
@@ -67,7 +67,8 @@ public class QuizControllerIntegrationTest {
 
         List<QuizQuestionResponse> questoes = List.of(
             new QuizQuestionResponse(1L, 1L, "Qual o nome do protagonista?",
-                "Jim Hawkins", "Long John Silver", "Capitão Smollett", "Billy Bones")
+                "Jim Hawkins", "Long John Silver", "Capitão Smollett", "Billy Bones",
+                "A", "Jim Hawkins é o jovem protagonista da história.")
         );
         when(quizService.getQuestions(1L)).thenReturn(questoes);
 
@@ -75,8 +76,8 @@ public class QuizControllerIntegrationTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].questionText").value("Qual o nome do protagonista?"))
-                // correctOption NÃO deve estar presente na resposta JSON
-                .andExpect(jsonPath("$[0].correctOption").doesNotExist());
+                .andExpect(jsonPath("$[0].correctOption").value("A"))
+                .andExpect(jsonPath("$[0].explanation").value("Jim Hawkins é o jovem protagonista da história."));
     }
 
     @Test
@@ -92,7 +93,7 @@ public class QuizControllerIntegrationTest {
         when(userRepository.findByEmail(email))
                 .thenReturn(Optional.of(user));
 
-        QuizResultResponse resposta = new QuizResultResponse(1, 1, 5, 5, 1, false);
+        QuizResultResponse resposta = new QuizResultResponse(1, 1, 5, 5, 1, false, null, false);
         when(quizService.submitQuiz(any(UUID.class), eq(1L), anyList()))
                 .thenReturn(resposta);
 

--- a/backend/src/test/java/com/librum/controller/ReadingControllerIntegrationTest.java
+++ b/backend/src/test/java/com/librum/controller/ReadingControllerIntegrationTest.java
@@ -76,7 +76,7 @@ public class ReadingControllerIntegrationTest {
         PhaseSegmentResponse segmentoResponse = new PhaseSegmentResponse(
                 1, 4, "Era uma vez um jovem chamado Jim Hawkins...",
                 3, "Fase 1: O Inicio da Aventura", 1,
-                "A Ilha do Tesouro", "Robert Louis Stevenson", "Aventura"
+                "A Ilha do Tesouro", "Robert Louis Stevenson", "Aventura", "aventura"
         );
 
         when(userRepository.findByEmail(any())).thenReturn(Optional.of(user));

--- a/backend/src/test/java/com/librum/service/QuizServiceTest.java
+++ b/backend/src/test/java/com/librum/service/QuizServiceTest.java
@@ -3,10 +3,13 @@ package com.librum.service;
 import com.librum.dto.QuizQuestionResponse;
 import com.librum.dto.QuizResultRequest;
 import com.librum.dto.QuizResultResponse;
+import com.librum.model.Book;
 import com.librum.model.Phase;
 import com.librum.model.QuizQuestion;
 import com.librum.model.User;
+import com.librum.repository.PhaseRepository;
 import com.librum.repository.QuizQuestionRepository;
+import com.librum.repository.UserProgressRepository;
 import com.librum.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +40,12 @@ public class QuizServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private UserProgressRepository userProgressRepository;
+
+    @Mock
+    private PhaseRepository phaseRepository;
+
     @InjectMocks
     private QuizService quizService;
 
@@ -55,10 +64,14 @@ public class QuizServiceTest {
         user.setXp(0);
         user.setLevel(1);
 
+        Book livro = mock(Book.class);
+        lenient().when(livro.getId()).thenReturn(1L);
+
         fase1 = new Phase();
         fase1.setId(1L);
         fase1.setPhaseNumber(1);
         fase1.setTitle("Fase 1");
+        fase1.setBook(livro);
 
         questao1 = new QuizQuestion();
         questao1.setId(1L);

--- a/backend/src/test/java/com/librum/service/QuizServiceUnlockTest.java
+++ b/backend/src/test/java/com/librum/service/QuizServiceUnlockTest.java
@@ -1,0 +1,161 @@
+package com.librum.service;
+
+import com.librum.dto.QuizResultRequest;
+import com.librum.dto.QuizResultResponse;
+import com.librum.model.*;
+import com.librum.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+class QuizServiceUnlockTest {
+
+    @Mock private QuizQuestionRepository quizQuestionRepository;
+    @Mock private UserProgressRepository userProgressRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private PhaseRepository phaseRepository;
+    @Mock private XpService xpService;
+
+    @InjectMocks private QuizService quizService;
+
+    private UUID userId;
+    private User user;
+    private Phase fase1;
+    private Phase fase2;
+    private List<QuizQuestion> questions;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        user = new User();
+        user.setXp(0);
+        user.setLevel(1);
+
+        Book book = mock(Book.class);
+        Genre genre = new Genre();
+        when(book.getGenre()).thenReturn(genre);
+        when(book.getId()).thenReturn(1L);
+
+        fase1 = mock(Phase.class);
+        when(fase1.getId()).thenReturn(1L);
+        when(fase1.getPhaseNumber()).thenReturn(1);
+        when(fase1.getBook()).thenReturn(book);
+
+        fase2 = mock(Phase.class);
+        when(fase2.getId()).thenReturn(2L);
+        when(fase2.getPhaseNumber()).thenReturn(2);
+        when(fase2.getBook()).thenReturn(book);
+
+        QuizQuestion q1 = new QuizQuestion();
+        q1.setId(1L);
+        q1.setCorrectOption('A');
+        q1.setPhase(fase1);
+
+        QuizQuestion q2 = new QuizQuestion();
+        q2.setId(2L);
+        q2.setCorrectOption('A');
+        q2.setPhase(fase1);
+
+        QuizQuestion q3 = new QuizQuestion();
+        q3.setId(3L);
+        q3.setCorrectOption('A');
+        q3.setPhase(fase1);
+
+        QuizQuestion q4 = new QuizQuestion();
+        q4.setId(4L);
+        q4.setCorrectOption('A');
+        q4.setPhase(fase1);
+
+        questions = List.of(q1, q2, q3, q4);
+
+        when(xpService.addXp(any(), anyInt())).thenReturn(user);
+    }
+
+    private List<QuizResultRequest.AnswerItem> buildAnswers(String... options) {
+        List<QuizResultRequest.AnswerItem> answers = new ArrayList<>();
+        for (int i = 0; i < options.length; i++) {
+            QuizResultRequest.AnswerItem item = new QuizResultRequest.AnswerItem();
+            item.setQuestionId((long) (i + 1));
+            item.setSelectedOption(options[i]);
+            answers.add(item);
+        }
+        return answers;
+    }
+
+    @Test
+    void submitQuiz_deve_marcar_quizCompleted_true_quando_aprovado() {
+        when(quizQuestionRepository.findByPhaseIdOrderByOrderIndex(1L)).thenReturn(questions);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(phaseRepository.findByBookIdAndPhaseNumber(any(), eq(2))).thenReturn(Optional.of(fase2));
+        when(userProgressRepository.findByUserIdAndPhaseId(userId, 1L)).thenReturn(Optional.empty());
+
+        List<QuizResultRequest.AnswerItem> answers = buildAnswers("A", "A", "A", "A");
+        QuizResultResponse result = quizService.submitQuiz(userId, 1L, answers);
+
+        assertThat(result.passed()).isTrue();
+        verify(userProgressRepository).save(argThat(p -> p.isQuizCompleted()));
+    }
+
+    @Test
+    void submitQuiz_nao_deve_marcar_quizCompleted_quando_reprovado_com_mais_de_2_erros() {
+        when(quizQuestionRepository.findByPhaseIdOrderByOrderIndex(1L)).thenReturn(questions);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        List<QuizResultRequest.AnswerItem> answers = buildAnswers("B", "B", "B", "A");
+        QuizResultResponse result = quizService.submitQuiz(userId, 1L, answers);
+
+        assertThat(result.passed()).isFalse();
+        verify(userProgressRepository, never()).save(any());
+    }
+
+    @Test
+    void submitQuiz_deve_retornar_passed_true_com_2_erros_ou_menos() {
+        when(quizQuestionRepository.findByPhaseIdOrderByOrderIndex(1L)).thenReturn(questions);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(phaseRepository.findByBookIdAndPhaseNumber(any(), eq(2))).thenReturn(Optional.of(fase2));
+        when(userProgressRepository.findByUserIdAndPhaseId(userId, 1L)).thenReturn(Optional.empty());
+
+        List<QuizResultRequest.AnswerItem> answers = buildAnswers("A", "A", "B", "B");
+        QuizResultResponse result = quizService.submitQuiz(userId, 1L, answers);
+
+        assertThat(result.passed()).isTrue();
+        assertThat(result.correctAnswers()).isEqualTo(2);
+    }
+
+    @Test
+    void submitQuiz_deve_retornar_passed_false_com_3_ou_mais_erros() {
+        when(quizQuestionRepository.findByPhaseIdOrderByOrderIndex(1L)).thenReturn(questions);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        List<QuizResultRequest.AnswerItem> answers = buildAnswers("B", "B", "B", "A");
+        QuizResultResponse result = quizService.submitQuiz(userId, 1L, answers);
+
+        assertThat(result.passed()).isFalse();
+        assertThat(result.nextPhaseId()).isNull();
+    }
+
+    @Test
+    void submitQuiz_deve_desbloquear_fase_seguinte_apenas_quando_aprovado() {
+        when(quizQuestionRepository.findByPhaseIdOrderByOrderIndex(1L)).thenReturn(questions);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(phaseRepository.findByBookIdAndPhaseNumber(any(), eq(2))).thenReturn(Optional.of(fase2));
+        when(userProgressRepository.findByUserIdAndPhaseId(userId, 1L)).thenReturn(Optional.empty());
+
+        List<QuizResultRequest.AnswerItem> answers = buildAnswers("A", "A", "A", "A");
+        QuizResultResponse result = quizService.submitQuiz(userId, 1L, answers);
+
+        assertThat(result.nextPhaseId()).isEqualTo(2L);
+    }
+}

--- a/backend/src/test/java/com/librum/service/ReadingServiceTest.java
+++ b/backend/src/test/java/com/librum/service/ReadingServiceTest.java
@@ -139,9 +139,9 @@ public class ReadingServiceTest {
         when(phaseRepository.findByBookIdOrderByPhaseNumber(any())).thenReturn(List.of(fase1, fase2, fase3));
         when(phaseSegmentRepository.countByPhaseId(anyLong())).thenReturn(4);
 
-        // fase 1 concluída → fase 2 destravada; fase 2 não concluída → fase 3 travada
-        when(userProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, 1L)).thenReturn(true);
-        when(userProgressRepository.existsByUserIdAndPhaseIdAndIsCompletedTrue(userId, 2L)).thenReturn(false);
+        // quiz da fase 1 concluído → fase 2 destravada; quiz da fase 2 não concluído → fase 3 travada
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 1L)).thenReturn(true);
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 2L)).thenReturn(false);
 
         List<PhaseReadingResponse> fases = readingService.getPhasesForGenre(userId, 10L);
 

--- a/backend/src/test/java/com/librum/service/ReadingServiceUnlockTest.java
+++ b/backend/src/test/java/com/librum/service/ReadingServiceUnlockTest.java
@@ -1,0 +1,138 @@
+package com.librum.service;
+
+import com.librum.model.*;
+import com.librum.repository.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = org.mockito.quality.Strictness.LENIENT)
+class ReadingServiceUnlockTest {
+
+    @Mock private BookRepository bookRepository;
+    @Mock private PhaseRepository phaseRepository;
+    @Mock private PhaseSegmentRepository phaseSegmentRepository;
+    @Mock private UserProgressRepository userProgressRepository;
+
+    @InjectMocks private ReadingService readingService;
+
+    private final UUID userId = UUID.randomUUID();
+
+    @Test
+    void isPhaseUnlocked_deve_retornar_true_para_fase_1_sempre() {
+        Book book = mock(Book.class);
+        when(book.getId()).thenReturn(1L);
+
+        Phase fase1 = mock(Phase.class);
+        when(fase1.getId()).thenReturn(1L);
+        when(fase1.getPhaseNumber()).thenReturn(1);
+        when(fase1.getBook()).thenReturn(book);
+
+        when(phaseRepository.findByBookIdOrderByPhaseNumber(1L)).thenReturn(List.of(fase1));
+
+        PhaseSegment segment = mock(PhaseSegment.class);
+        when(segment.getSegmentNumber()).thenReturn(1);
+        when(segment.getContent()).thenReturn("conteudo");
+        when(segment.getEstimatedMinutes()).thenReturn(3);
+        when(phaseRepository.findById(1L)).thenReturn(Optional.of(fase1));
+        when(phaseSegmentRepository.findByPhaseIdAndSegmentNumber(1L, 1))
+                .thenReturn(Optional.of(segment));
+        when(phaseSegmentRepository.countByPhaseId(1L)).thenReturn(3);
+
+        Genre genre = mock(Genre.class);
+        when(genre.getName()).thenReturn("Aventura");
+        when(genre.getSlug()).thenReturn("aventura");
+        when(book.getGenre()).thenReturn(genre);
+        when(book.getTitle()).thenReturn("A Ilha do Tesouro");
+        when(book.getAuthor()).thenReturn("Robert Louis Stevenson");
+        when(fase1.getTitle()).thenReturn("Fase 1");
+
+        readingService.getPhaseSegment(userId, 1L, 1);
+
+        verify(userProgressRepository, never())
+                .existsByUserIdAndPhaseIdAndQuizCompletedTrue(any(), any());
+    }
+
+    @Test
+    void isPhaseUnlocked_deve_retornar_false_se_quiz_anterior_nao_concluido() {
+        Book book = mock(Book.class);
+        when(book.getId()).thenReturn(1L);
+
+        Phase fase1 = mock(Phase.class);
+        when(fase1.getId()).thenReturn(1L);
+        when(fase1.getPhaseNumber()).thenReturn(1);
+        when(fase1.getBook()).thenReturn(book);
+
+        Phase fase2 = mock(Phase.class);
+        when(fase2.getId()).thenReturn(2L);
+        when(fase2.getPhaseNumber()).thenReturn(2);
+        when(fase2.getBook()).thenReturn(book);
+
+        when(phaseRepository.findById(2L)).thenReturn(Optional.of(fase2));
+        when(phaseRepository.findByBookIdOrderByPhaseNumber(1L))
+                .thenReturn(List.of(fase1, fase2));
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 1L))
+                .thenReturn(false);
+
+        org.springframework.security.access.AccessDeniedException ex =
+                org.junit.jupiter.api.Assertions.assertThrows(
+                        org.springframework.security.access.AccessDeniedException.class,
+                        () -> readingService.getPhaseSegment(userId, 2L, 1)
+                );
+
+        assertThat(ex.getMessage()).contains("bloqueada");
+    }
+
+    @Test
+    void isPhaseUnlocked_deve_retornar_true_se_quiz_anterior_concluido() {
+        Book book = mock(Book.class);
+        when(book.getId()).thenReturn(1L);
+
+        Phase fase1 = mock(Phase.class);
+        when(fase1.getId()).thenReturn(1L);
+        when(fase1.getPhaseNumber()).thenReturn(1);
+        when(fase1.getBook()).thenReturn(book);
+
+        Phase fase2 = mock(Phase.class);
+        when(fase2.getId()).thenReturn(2L);
+        when(fase2.getPhaseNumber()).thenReturn(2);
+        when(fase2.getBook()).thenReturn(book);
+
+        PhaseSegment segment = mock(PhaseSegment.class);
+        when(segment.getSegmentNumber()).thenReturn(1);
+        when(segment.getContent()).thenReturn("conteudo");
+        when(segment.getEstimatedMinutes()).thenReturn(3);
+
+        Genre genre = mock(Genre.class);
+        when(genre.getName()).thenReturn("Aventura");
+        when(genre.getSlug()).thenReturn("aventura");
+        when(book.getGenre()).thenReturn(genre);
+        when(book.getTitle()).thenReturn("A Ilha do Tesouro");
+        when(book.getAuthor()).thenReturn("Robert Louis Stevenson");
+        when(fase2.getTitle()).thenReturn("Fase 2");
+
+        when(phaseRepository.findById(2L)).thenReturn(Optional.of(fase2));
+        when(phaseRepository.findByBookIdOrderByPhaseNumber(1L))
+                .thenReturn(List.of(fase1, fase2));
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 1L))
+                .thenReturn(true);
+        when(phaseSegmentRepository.findByPhaseIdAndSegmentNumber(2L, 1))
+                .thenReturn(Optional.of(segment));
+        when(phaseSegmentRepository.countByPhaseId(2L)).thenReturn(3);
+
+        readingService.getPhaseSegment(userId, 2L, 1);
+
+        verify(userProgressRepository)
+                .existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 1L);
+    }
+}

--- a/backend/src/test/resources/application-test.properties
+++ b/backend/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.flyway.enabled=false


### PR DESCRIPTION
Descrição

  > Implementa suporte completo a US08 (progresso por fase) e US09 (resumo pós-quiz), incluindo migrations de schema e conteúdo, nova regra de desbloqueio por quiz concluído, atualização dos DTOs e testes de unidade/integração.
  > Por quê: o critério de desbloqueio de fases mudou de "leitura concluída" para "quiz concluído" (ADR-0009 - Template Method). Isso exigiu novo campo quiz_completed no UserProgress, campo explanation nas questões, e ajuste nos services ReadingService e QuizService.

  Closes #107 
  Closes #108 
  Closes #109 
  Closes #114 
  Closes #115 

  ---
  Tipo de Mudança

  - [x] Nova funcionalidade
  - [ ] Correção de bug
  - [ ] Melhoria de código
  - [ ] Documentação
  - [x] Testes
  - [ ] Configuração/infraestrutura

  ---
  Como Testar

  1. Subir o banco limpo e rodar ./mvnw flyway:migrate — verificar nos logs: "Flyway applied 8 migrations"
  2. Criar um usuário, ler todos os segmentos da Fase 1 e submeter o quiz com ≤ 2 erros — resposta deve conter "passed": true e "nextPhaseId": <id da fase 2>
  3. Repetir o quiz com > 2 erros — resposta deve conter "passed": false e "nextPhaseId": null; a Fase 2 deve permanecer bloqueada no GET /genres/{genreId}/phases
  4. Verificar que as Fases 5, 6 e 7 existem com 3 segmentos cada: GET /reading/{phaseId}/1 para phaseId 5, 6 e 7
  5. Verificar que GET /quiz/{phaseId} retorna os campos explanation e correctOption em cada questão
  6. Rodar ./mvnw test — todos os testes devem passar

  Resultado esperado: 8 migrations aplicadas, regra de desbloqueio baseada em quiz_completed, campos passed/nextPhaseId/explanation/correctOption/genreSlug presentes nas respostas, suite de testes verde.

  ---
  Checklist

  - [ ] Código compila e executa sem erros
  - [x] Testes adicionados/atualizados e passando
  - [ ] Padrões de código seguidos (lint/formatação)
  - [x] Commits seguem Conventional Commits
  - [ ] Branch atualizada com main