### PR TITLE
fix(db): reescreve fases 3 e 4 e corrige quiz para remover repeticao

### DIFF
--- a/backend/src/main/resources/db/migration/V10__corrige_quiz_fases_3_4.sql
+++ b/backend/src/main/resources/db/migration/V10__corrige_quiz_fases_3_4.sql
@@ -1,0 +1,101 @@
+DELETE FROM quiz_questions
+WHERE phase_id IN (
+    SELECT p.id FROM phases p JOIN books b ON p.book_id = b.id
+    WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number IN (3, 4)
+);
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que Jim fez quando os primeiros tiros soaram no desembarque?',
+    'Correu para o interior da floresta',
+    'Voltou nadando para o navio',
+    'Escondeu-se atrás dos botes na praia',
+    'Enfrentou os piratas sozinho',
+    'A', 1,
+    'No meio da confusão do desembarque, Jim correu para o interior da floresta sem olhar para trás, e foi lá que encontrou Ben Gunn.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Quem Jim encontrou escondido na ilha?',
+    'O capitão Flint',
+    'Ben Gunn',
+    'Israel Hands',
+    'Long John Silver',
+    'B', 2,
+    'Jim encontrou Ben Gunn, um homem magro e em farrapos que havia sido abandonado na ilha.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Há quanto tempo Ben Gunn estava abandonado na ilha?',
+    'Um ano',
+    'Três anos',
+    'Seis meses',
+    'Dez anos',
+    'B', 3,
+    'Ben Gunn contou que havia sido deixado na ilha três anos antes, como castigo dos próprios companheiros.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que Ben Gunn ofereceu em troca de ajuda para deixar a ilha?',
+    'Um mapa novo do tesouro',
+    'Seu conhecimento da ilha e ajuda contra os piratas',
+    'Uma parte do navio',
+    'Armas escondidas na praia',
+    'B', 4,
+    'Ben Gunn conhecia cada trilha e caverna da ilha e se ofereceu para ficar do lado dos homens leais em troca de ajuda para voltar para casa.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Para onde os homens leais ao capitão se refugiaram?',
+    'Para o navio Hispaniola',
+    'Para uma caverna nas colinas',
+    'Para o forte de madeira',
+    'Para a praia ao sul',
+    'C', 1,
+    'Os homens leais se refugiaram num velho forte de madeira cercado por uma paliçada, o único ponto onde poucos poderiam resistir a muitos.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Por que a situação dos homens no forte era difícil?',
+    'Estavam sem nenhum mantimento',
+    'Eram poucos contra a maioria da tripulação',
+    'Não tinham armas',
+    'O forte estava em ruínas',
+    'B', 2,
+    'Os homens leais eram minoria diante da tripulação que agora seguia Long John Silver sem disfarce.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'Que decisão silenciosa Jim tomou durante a noite no forte?',
+    'Fugir da ilha sozinho',
+    'Render-se aos piratas',
+    'Não ficar apenas esperando e agir se tivesse a chance',
+    'Roubar o mapa do capitão',
+    'C', 3,
+    'Deitado no chão do forte, Jim decidiu que não ficaria só esperando e faria a sua parte se a oportunidade aparecesse.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4;
+
+INSERT INTO quiz_questions (phase_id, question_text, option_a, option_b, option_c, option_d, correct_option, order_index, explanation)
+SELECT p.id,
+    'O que o capitão Smollett anunciou ao amanhecer?',
+    'Que iriam abandonar o forte',
+    'Que um ataque dos piratas era iminente e definiu as posições',
+    'Que o tesouro havia sido encontrado',
+    'Que Silver tinha se rendido',
+    'B', 4,
+    'O capitão avisou que um ataque era questão de horas e distribuiu as posições de cada um na defesa do forte.'
+FROM phases p JOIN books b ON p.book_id = b.id
+WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4;

--- a/backend/src/main/resources/db/migration/V9__reescreve_fases_3_4.sql
+++ b/backend/src/main/resources/db/migration/V9__reescreve_fases_3_4.sql
@@ -1,0 +1,56 @@
+UPDATE phases SET title = 'Fase 4: O Forte de Madeira'
+WHERE phase_number = 4 AND book_id = (SELECT id FROM books WHERE title = 'A Ilha do Tesouro');
+
+UPDATE phase_segments SET content =
+'Desembarcamos na ilha em dois grupos, e a tensão era tão espessa quanto a névoa que subia da praia. Bastou um gesto em falso para que os primeiros tiros ecoassem entre as árvores, e os homens de Silver mostraram de uma vez de que lado estavam.
+
+No meio da confusão, corri para o interior da floresta sem olhar para trás. O coração batia tão forte que eu mal ouvia os gritos que ficavam para trás. Embrenhei-me no mato fechado até que as vozes sumissem e só restasse o som da minha própria respiração.
+
+Foi quando uma figura magra saltou de detrás de um tronco e me encarou com olhos arregalados. Estava coberto de farrapos e tinha a barba crescida, mas havia algo gentil no jeito como ergueu as mãos, mostrando que não queria me fazer mal.',
+estimated_minutes = 3
+WHERE segment_number = 1 AND phase_id = (SELECT p.id FROM phases p JOIN books b ON p.book_id = b.id WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3);
+
+UPDATE phase_segments SET content =
+'O homem se apresentou como Ben Gunn. Contou que havia sido abandonado naquela ilha três anos antes, deixado para trás pelos próprios companheiros como castigo, e que desde então vivia de cabras e ostras, sonhando em voltar para casa.
+
+Três anos sozinho o haviam deixado estranho no falar, mas não tolo. Ele conhecia cada enseada, cada trilha e cada caverna daquele lugar melhor do que qualquer mapa. E garantiu, baixando a voz como se as árvores pudessem escutar, que sabia segredos sobre o tesouro do Capitão Flint que os piratas nem imaginavam.
+
+Em troca de ajuda para deixar a ilha e de uma parte justa, Ben Gunn se ofereceu para ficar do nosso lado. Eu não sabia se podia confiar nele, mas algo me dizia que aquele encontro não tinha sido por acaso.',
+estimated_minutes = 4
+WHERE segment_number = 2 AND phase_id = (SELECT p.id FROM phases p JOIN books b ON p.book_id = b.id WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3);
+
+UPDATE phase_segments SET content =
+'Ben Gunn me explicou onde os homens leais ao capitão haviam se refugiado: um velho forte de madeira, cercado por uma paliçada, construído tempos atrás por buscadores de ouro. Era o único ponto da ilha onde poucos poderiam resistir a muitos.
+
+Voltei na direção indicada, contornando o terreno aberto para não ser visto, até avistar a paliçada e a bandeira inglesa hasteada sobre ela. O doutor Livesey e o capitão Smollett me receberam aliviados, pois já me davam por perdido.
+
+Contei tudo o que Ben Gunn havia me dito. O capitão ouviu em silêncio, pesando cada palavra, e concluiu que aquele forte seria o nosso refúgio enquanto pensávamos no próximo passo. Pela primeira vez desde o desembarque, senti que ainda tínhamos uma chance.',
+estimated_minutes = 3
+WHERE segment_number = 3 AND phase_id = (SELECT p.id FROM phases p JOIN books b ON p.book_id = b.id WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 3);
+
+UPDATE phase_segments SET content =
+'O forte de madeira era simples, mas resistente: paredes grossas de troncos e uma clareira ao redor que impedia qualquer aproximação despercebida. Lá dentro, fizemos a contagem dos nossos e o número não animava ninguém.
+
+Éramos poucos homens leais contra a maioria da tripulação, que agora seguia Long John Silver sem disfarce. O capitão Smollett, porém, não demonstrava medo. Distribuiu tarefas com a calma de quem já havia enfrentado coisa pior e nos lembrou de que paredes firmes valiam por muitos braços.
+
+Enquanto organizávamos os mantimentos e a pólvora, eu observava o doutor Livesey cuidar de tudo com atenção. Havia nele uma serenidade estranha, como se soubesse de algo que ainda não havia nos contado.',
+estimated_minutes = 3
+WHERE segment_number = 1 AND phase_id = (SELECT p.id FROM phases p JOIN books b ON p.book_id = b.id WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4);
+
+UPDATE phase_segments SET content =
+'A primeira noite no forte foi longa. Cada estalo de galho lá fora parecia o passo de um pirata, e revezávamos a vigília nas frestas da paliçada, de olhos fixos na escuridão da floresta.
+
+Eu não conseguia dormir. Pensava em Ben Gunn, sozinho na ilha por tanto tempo, e no segredo que ele guardava sobre o tesouro. Comecei a desconfiar de que o mapa que tanto sangue já havia custado talvez não valesse o que todos imaginavam.
+
+Guardei essa desconfiança para mim. Mas, deitado no chão de terra batida do forte, tomei uma decisão silenciosa: não ficaria apenas esperando. Se a chance aparecesse, eu faria a minha parte, custasse o que custasse.',
+estimated_minutes = 3
+WHERE segment_number = 2 AND phase_id = (SELECT p.id FROM phases p JOIN books b ON p.book_id = b.id WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4);
+
+UPDATE phase_segments SET content =
+'Ao amanhecer, o capitão reuniu todos e foi direto: os piratas não nos deixariam em paz, e um ataque era questão de horas. Cada homem recebeu sua posição, e a minha era ajudar a carregar as armas e vigiar a clareira pelos fundos.
+
+Trelawney, que era um excelente atirador, escolheu a janela com melhor ângulo. Livesey preparou o que tinha para tratar feridos. Havia uma coragem quieta no ar, dessas que não precisam de palavras para se reconhecerem.
+
+Ficamos prontos, em silêncio, ouvindo o vento na copa das árvores. Em algum lugar lá fora, Silver e seus homens preparavam o golpe. O cerco ao forte estava prestes a começar, e nós o esperávamos firmes.',
+estimated_minutes = 4
+WHERE segment_number = 3 AND phase_id = (SELECT p.id FROM phases p JOIN books b ON p.book_id = b.id WHERE b.title = 'A Ilha do Tesouro' AND p.phase_number = 4);


### PR DESCRIPTION
## Descrição

  > Reescreve o conteúdo das Fases 3 e 4 de A Ilha do Tesouro e corrige o quiz dessas fases, para que as 7 fases formem um arco linear único. O cerco ao forte, a tomada do Hispaniola e o desfecho passam a existir somente nas Fases 5 a 7.
  > Por quê: o seed inicial (V3) já narrava o livro inteiro em 4 fases e a V7 recontava a segunda metade, repetindo eventos e perguntas. As migrations V1 a V8 não foram editadas; a correção é forward-only com V9 e V10.

  Closes #121

  ---
## Tipo de Mudança

  - [x] Correção de bug
  - [ ] Nova funcionalidade
  - [ ] Melhoria de código
  - [ ] Documentação
  - [ ] Testes
  - [ ] Configuração/infraestrutura

  ---
## Como Testar

  1. Subir o banco limpo: docker compose up -d
  2. Rodar a aplicação e verificar nos logs que o Flyway aplicou V9 e V10
  3. Consultar phase_segments das Fases 3 e 4 e confirmar que narram chegada à ilha, Ben Gunn e a espera no forte
  4. Consultar quiz_questions das Fases 3 e 4 e confirmar que as perguntas refletem o novo conteúdo, sem repetir as Fases 5 a 7
  5. Ler as Fases 1 a 7 em sequência e confirmar que nenhum evento se repete

  Resultado esperado: arco único sem repetição, quiz das Fases 3 e 4 corrigido, migrations aplicadas no Postgres.

  ---
## Checklist

  - [ ] Código compila e executa sem erros
  - [ ] Testes adicionados/atualizados e passando
  - [ ] Padrões de código seguidos (lint/formatação)
  - [x] Commits seguem Conventional Commits
  - [ ] Branch atualizada com main