### PR TITLE
feat(ui): reestiliza trilha de fases e leitura e remove mock enganoso

### DIFF
--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -1,21 +1,21 @@
-import { createContext, useState, useContext, useEffect } from 'react';
+import { createContext, useState, useContext } from 'react';
 
 const AuthContext = createContext();
 
-export const AuthProvider = ({ children }) => {
-  const [user, setUser] = useState(null); 
-  const [token, setToken] = useState(null);
-  const [loading, setLoading] = useState(true);
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAuth = () => useContext(AuthContext);
 
-  useEffect(() => {
-      const saved = localStorage.getItem('user');
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        setUser(parsed);
-        setToken(parsed.token ?? null);
-      }
-      setLoading(false);
-    }, []);
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(() => {
+    const saved = localStorage.getItem('user');
+    return saved ? JSON.parse(saved) : null;
+  });
+  const [token, setToken] = useState(() => {
+    const saved = localStorage.getItem('user');
+    if (!saved) return null;
+    const parsed = JSON.parse(saved);
+    return parsed.token ?? null;
+  });
 
   const loginUser = (userData) => {
     localStorage.setItem('user', JSON.stringify(userData));
@@ -32,10 +32,8 @@ export const AuthProvider = ({ children }) => {
   const isAuthenticated = !!token;
 
   return (
-    <AuthContext.Provider value={{ user, loginUser, logoutUser, loading, isAuthenticated, token }}>
-      {!loading && children}
+    <AuthContext.Provider value={{ user, loginUser, logoutUser, loading: false, isAuthenticated, token }}>
+      {children}
     </AuthContext.Provider>
   );
 };
-
-export const useAuth = () => useContext(AuthContext);

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -6,6 +6,7 @@ const AuthContext = createContext();
 export const useAuth = () => useContext(AuthContext);
 
 export const AuthProvider = ({ children }) => {
+  // Lazy initializer: localStorage é síncrono, então o valor já está disponível na primeira renderização — sem necessidade de useEffect
   const [user, setUser] = useState(() => {
     const saved = localStorage.getItem('user');
     return saved ? JSON.parse(saved) : null;
@@ -32,7 +33,7 @@ export const AuthProvider = ({ children }) => {
   const isAuthenticated = !!token;
 
   return (
-    <AuthContext.Provider value={{ user, loginUser, logoutUser, loading: false, isAuthenticated, token }}>
+    <AuthContext.Provider value={{ user, loginUser, logoutUser, loading: false /* leitura do localStorage é síncrona: o estado já está pronto na primeira renderização, nunca há carregamento assíncrono */, isAuthenticated, token }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/PhaseListPage.css
+++ b/frontend/src/pages/PhaseListPage.css
@@ -1,194 +1,103 @@
-.phase-list-container {
-  display: flex;
-  max-width: 1200px;
+.trilha-page {
+  max-width: 760px;
   margin: 0 auto;
-  min-height: 80vh;
-  font-family: 'Inter', sans-serif;
+  padding: 2rem 1.5rem;
 }
 
-.phase-list-sidebar {
-  width: 350px;
-  padding: 40px;
-  background: #FAF8F5;
-  border-right: 1px solid #EAEAEA;
+.trilha-header {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  margin-bottom: 2rem;
 }
 
-.phase-list-sidebar h2 {
-  font-size: 1.5rem;
-  color: #D9530F;
-  margin-bottom: 10px;
+.trilha-header h1 {
+  margin: 0;
 }
 
-.btn-back {
-  background: none;
-  border: none;
-  color: #F97316;
-  font-weight: 600;
-  cursor: pointer;
-  padding: 0;
-  margin-bottom: 30px;
+.trilha-autor {
+  color: var(--color-text-muted);
+  margin: 0.25rem 0 1rem;
 }
 
-.book-cover-card {
-  background: #F97316;
-  border-radius: 12px;
-  padding: 20px;
-  display: flex;
-  justify-content: center;
-  position: relative;
-  margin-bottom: 20px;
-}
-
-.book-cover-image {
-  background: white;
-  width: 120px;
-  height: 180px;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-  position: relative;
-}
-
-.book-mascot {
-  position: absolute;
-  right: -40px;
-  bottom: -20px;
-  width: 100px;
-}
-
-.book-meta {
-  color: #666;
-  font-size: 0.875rem;
-  margin-bottom: 30px;
-}
-
-.progress-section {
-  background: white;
-  padding: 20px;
-  border-radius: 12px;
-  border: 1px solid #EAEAEA;
-  margin-bottom: 20px;
-}
-
-.progress-section h3 {
-  font-size: 0.75rem;
-  color: #666;
-  margin-bottom: 10px;
-  letter-spacing: 1px;
-}
-
-.progress-bar-container {
-  height: 8px;
-  background: #EAEAEA;
-  border-radius: 4px;
-  margin-bottom: 10px;
-}
-
-.progress-bar {
-  height: 100%;
-  background: #F97316;
-  border-radius: 4px;
-}
-
-.progress-text {
-  font-size: 0.875rem;
-  color: #666;
-}
-
-.btn-continue {
-  width: 100%;
-  background: #D9530F;
-  color: white;
-  border: none;
-  padding: 15px;
-  border-radius: 8px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.phase-list-content {
-  flex: 1;
-  padding: 40px;
-  background: white;
-}
-
-.phase-list-header h3 {
-  font-size: 1rem;
-  color: #666;
-  margin-bottom: 5px;
-  letter-spacing: 1px;
-}
-
-.phase-list-header p {
-  color: #999;
-  font-size: 0.875rem;
-  margin-bottom: 40px;
-}
-
-.phase-path {
-  position: relative;
-  min-height: 600px;
-}
-
-.phase-node {
-  position: absolute;
+.trilha-progresso {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  cursor: pointer;
-  transition: transform 0.2s;
+  gap: 0.4rem;
+  margin-bottom: 1.25rem;
 }
 
-.phase-node:hover {
-  transform: scale(1.1);
+.trilha-progresso span {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
 }
 
-.phase-node.locked {
-  cursor: not-allowed;
-  opacity: 0.5;
+.trilha-lista {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
 }
 
-.phase-circle {
-  width: 60px;
-  height: 60px;
-  border-radius: 50%;
+.trilha-no {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-weight: bold;
-  font-size: 1.25rem;
-  margin-bottom: 10px;
-  background: #EAEAEA;
-  color: #666;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  position: relative;
 }
 
-.phase-node.completed .phase-circle {
-  background: #D9530F;
-  color: white;
-}
-
-.phase-node.active .phase-circle {
-  background: white;
-  border: 4px solid #D9530F;
-  color: #D9530F;
-  box-shadow: 0 0 0 10px rgba(217, 83, 15, 0.2);
-}
-
-.phase-label {
-  font-size: 0.875rem;
-  color: #666;
-  font-weight: 500;
-}
-
-.phase-connector {
+.trilha-no:not(:last-child)::before {
+  content: '';
   position: absolute;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 32px;
-  color: #EAEAEA;
+  left: 27px;
+  top: 56px;
+  width: 2px;
+  height: calc(100% - 8px);
+  background: var(--color-border);
 }
 
-.phase-connector-arrow {
-  font-size: 1.4rem;
-  line-height: 1;
+.trilha-no__circulo {
+  width: 56px;
+  height: 56px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 2px solid var(--color-border);
+  background: var(--color-surface);
+  font-family: var(--font-display);
+  font-size: 1.2rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.trilha-no--concluida .trilha-no__circulo {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #fff;
+}
+
+.trilha-no--ativa .trilha-no__circulo {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 0 0 4px rgba(58, 47, 128, 0.18);
+}
+
+.trilha-no--bloqueada .trilha-no__circulo {
+  cursor: not-allowed;
+  color: var(--color-text-muted);
+}
+
+.trilha-no__titulo {
+  font-weight: 600;
+}
+
+.trilha-no--bloqueada .trilha-no__titulo {
+  color: var(--color-text-muted);
 }

--- a/frontend/src/pages/PhaseListPage.jsx
+++ b/frontend/src/pages/PhaseListPage.jsx
@@ -1,104 +1,84 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ReadingService } from '../services/ReadingService';
+import ProgressBar from '../components/ui/ProgressBar';
+import Button from '../components/ui/Button';
+import LoadingState from '../components/ui/LoadingState';
+import ErrorState from '../components/ui/ErrorState';
 import './PhaseListPage.css';
-import mascote from '../assets/librum-mascote-principal.png';
-import livro from '../assets/books/ilha-do-tesouro.png';
 
 export default function PhaseListPage() {
   const { genreId } = useParams();
   const navigate = useNavigate();
   const [phases, setPhases] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState(false);
+
+  const [retry, setRetry] = useState(0);
 
   useEffect(() => {
-    const loadPhases = async () => {
-      const data = await ReadingService.getPhases(genreId);
-      setPhases(data);
-      setLoading(false);
+    let cancelled = false;
+    const carregar = async () => {
+      setLoading(true);
+      setErro(false);
+      try {
+        const data = await ReadingService.getPhases(genreId);
+        if (!cancelled) setPhases(data);
+      } catch (e) {
+        console.error(e);
+        if (!cancelled) setErro(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
     };
-    loadPhases();
-  }, [genreId]);
+    carregar();
+    return () => { cancelled = true; };
+  }, [genreId, retry]);
 
-  const handlePhaseClick = (phase) => {
-    if (phase.isUnlocked) {
-      navigate(`/reading/${phase.id}/1`);
-    }
-  };
-
-  if (loading) return <div>Carregando fases...</div>;
+  if (loading) return <LoadingState message="Carregando fases..." />;
+  if (erro) return <ErrorState message="Não foi possível carregar as fases." onRetry={() => setRetry(r => r + 1)} />;
+  if (phases.length === 0) return <LoadingState message="Nenhuma fase disponível." />;
 
   const completedCount = phases.filter(p => p.isCompleted).length;
   const totalCount = phases.length;
-  const progressPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
-  const nextPhase = phases.find(p => p.isUnlocked && !p.isCompleted);
-  const continueTarget = nextPhase || phases[0];
-  const pathHeight = Math.max(phases.length * 80 + 120, 600);
+  const progressPercent = Math.round((completedCount / totalCount) * 100);
+  const nextPhase = phases.find(p => p.isUnlocked && !p.isCompleted) || phases[0];
+
+  const irParaFase = (phase) => {
+    if (phase.isUnlocked) navigate(`/reading/${phase.id}/1`);
+  };
 
   return (
-    <div className="phase-list-container">
-      <div className="phase-list-sidebar">
-        <button onClick={() => navigate('/genres')} className="btn-back">← Livros</button>
-
-        <div className="book-cover-card">
-          <div className="book-cover-image">
-            <img src={livro} alt="A Ilha do Tesouro" width="100%" />
-            <img src={mascote} alt="Mascote" className="book-mascot" />
-          </div>
+    <div className="trilha-page">
+      <header className="trilha-header">
+        <h1>{phases[0]?.bookTitle}</h1>
+        <p className="trilha-autor">{phases[0]?.bookAuthor} - domínio público</p>
+        <div className="trilha-progresso">
+          <ProgressBar value={progressPercent} />
+          <span>{completedCount} de {totalCount} fases concluídas</span>
         </div>
+        <Button variant="secondary" onClick={() => irParaFase(nextPhase)}>
+          Continuar na Fase {nextPhase?.phaseNumber}
+        </Button>
+      </header>
 
-        <h2>A Ilha do Tesouro</h2>
-        <p className="book-meta">Robert Louis Stevenson · domínio público · Aventura</p>
-
-        <div className="progress-section">
-          <h3>PROGRESSO GERAL</h3>
-          <div className="progress-bar-container">
-            <div className="progress-bar" style={{ width: `${progressPercent}%` }}></div>
-          </div>
-          <p className="progress-text">Fase {completedCount} de {totalCount} concluída - {progressPercent}% do livro lido</p>
-        </div>
-
-        <button className="btn-continue" onClick={() => handlePhaseClick(continueTarget)}>
-          ▶ Continuar - Fase {continueTarget?.phaseNumber}
-        </button>
-      </div>
-
-      <div className="phase-list-content">
-        <div className="phase-list-header">
-          <h3>TRILHA DE FASES · AVENTURA</h3>
-          <p>Complete cada fase para desbloquear a próxima</p>
-        </div>
-
-        <div className="phase-path" style={{ height: `${pathHeight}px` }}>
-          {phases.map((phase, index) => (
-            <React.Fragment key={phase.id}>
-              <div
-                className={`phase-node ${phase.isCompleted ? 'completed' : ''} ${phase.isUnlocked && !phase.isCompleted ? 'active' : ''} ${!phase.isUnlocked ? 'locked' : ''}`}
-                onClick={() => handlePhaseClick(phase)}
-                style={{ top: `${index * 80}px`, left: `${(index % 2 === 0 ? 20 : 60)}%` }}
+      <ol className="trilha-lista">
+        {phases.map((phase) => {
+          const estado = phase.isCompleted ? 'concluida' : phase.isUnlocked ? 'ativa' : 'bloqueada';
+          return (
+            <li key={phase.id} className={`trilha-no trilha-no--${estado}`}>
+              <button
+                className="trilha-no__circulo"
+                onClick={() => irParaFase(phase)}
+                disabled={!phase.isUnlocked}
               >
-                <div className="phase-circle">
-                  {phase.isCompleted ? '✓' : phase.isUnlocked ? phase.phaseNumber : '🔒'}
-                </div>
-                <span className="phase-label">Fase {phase.phaseNumber}</span>
-              </div>
-              {index < phases.length - 1 && (
-                <div
-                  className="phase-connector"
-                  style={{
-                    position: 'absolute',
-                    top: `${index * 80 + 55}px`,
-                    left: `${(index % 2 === 0 ? 20 : 60) + 2.5}%`,
-                    width: '60px'
-                  }}
-                >
-                  <span className="phase-connector-arrow">↓</span>
-                </div>
-              )}
-            </React.Fragment>
-          ))}
-        </div>
-      </div>
+                {phase.isCompleted ? '✓' : phase.isUnlocked ? phase.phaseNumber : '🔒'}
+              </button>
+              <span className="trilha-no__titulo">{phase.title}</span>
+            </li>
+          );
+        })}
+      </ol>
     </div>
   );
 }

--- a/frontend/src/pages/ReadingPage.css
+++ b/frontend/src/pages/ReadingPage.css
@@ -261,3 +261,7 @@
   font-size: 0.75rem;
   color: #999;
 }
+
+.reading-content .text-body {
+  font-family: var(--font-reading);
+}

--- a/frontend/src/pages/ReadingPage.css
+++ b/frontend/src/pages/ReadingPage.css
@@ -21,7 +21,7 @@
   grid-template-columns: 270px 1fr 250px;
   align-items: center;
   padding: 10px 30px;
-  background-color: #3B2A63;
+  background-color: var(--color-primary);
   color: white;
   height: 72px;
 }
@@ -33,7 +33,7 @@
 }
 
 .btn-icon {
-  background: #2D1F4C;
+  background: var(--color-primary-700);
   border: none;
   color: white;
   width: 32px;
@@ -63,7 +63,7 @@
 }
 
 .breadcrumb .highlight {
-  color: #F97316;
+  color: var(--color-accent);
   font-weight: 600;
 }
 
@@ -71,7 +71,7 @@
   flex: 1;
   max-width: 800px;
   font-size: 0.875rem;
-  color: #D1C4E9;
+  color: var(--color-text-muted);
   text-align: center;
   margin: 0 auto;
 }
@@ -91,7 +91,7 @@
 
 .progress-fill {
   height: 100%;
-  background: #F97316;
+  background: var(--color-accent);
   border-radius: 2px;
 }
 
@@ -119,7 +119,7 @@
 
 .sidebar-section .label {
   font-size: 0.75rem;
-  color: #999;
+  color: var(--color-text-muted);
   font-weight: 600;
   margin-bottom: 5px;
 }
@@ -130,7 +130,7 @@
 }
 
 .sidebar-section .value.highlight {
-  color: #F97316;
+  color: var(--color-accent);
   font-weight: 600;
 }
 
@@ -147,7 +147,7 @@
 .mascot-quote {
   font-style: italic;
   font-size: 0.875rem;
-  color: #666;
+  color: var(--color-text-muted);
 }
 
 .reading-content {
@@ -160,7 +160,7 @@
 
 .content-meta {
   font-size: 0.75rem;
-  color: #999;
+  color: var(--color-text-muted);
   letter-spacing: 1px;
   margin-bottom: 40px;
   font-weight: 600;
@@ -193,11 +193,11 @@
   padding-top: 20px;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
   font-size: 0.875rem;
-  color: #666;
+  color: var(--color-text-muted);
 }
 
 .btn-next {
-  background: #F97316;
+  background: var(--color-accent);
   color: white;
   border: none;
   padding: 10px 20px;
@@ -215,7 +215,7 @@
 
 .visual-controls .label {
   font-size: 0.75rem;
-  color: #999;
+  color: var(--color-text-muted);
   font-weight: 600;
   margin-bottom: 15px;
 }
@@ -226,7 +226,7 @@
   padding: 12px;
   margin-bottom: 10px;
   border-radius: 8px;
-  border: 1px solid #EAEAEA;
+  border: 1px solid var(--color-border);
   background: white;
   color: #333;
   font-weight: 600;
@@ -235,9 +235,9 @@
 }
 
 .theme-btn.active {
-  background: #3B2A63;
+  background: var(--color-primary);
   color: white;
-  border-color: #3B2A63;
+  border-color: var(--color-primary);
 }
 
 .slider-group {
@@ -253,13 +253,13 @@
 
 .slider-group input[type="range"] {
   width: 120px;
-  accent-color: #3B2A63;
+  accent-color: var(--color-primary);
 }
 
 .save-status {
   margin-top: 20px;
   font-size: 0.75rem;
-  color: #999;
+  color: var(--color-text-muted);
 }
 
 .reading-content .text-body {

--- a/frontend/src/pages/ReadingPage.jsx
+++ b/frontend/src/pages/ReadingPage.jsx
@@ -13,29 +13,33 @@ export default function ReadingPage() {
   const navigate = useNavigate();
   const [content, setContent] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState(false);
 
-  const [theme, setTheme] = useState('padrao');
-  const [fontSize, setFontSize] = useState(17);
-  const [lineSpacing, setLineSpacing] = useState(1.9);
-  const [contentStyle, setContentStyle] = useState(() => applyTheme('padrao', 17, 1.9));
-
-  useEffect(() => {
-    const savedTheme = localStorage.getItem('librum_theme') || 'padrao';
-    const savedFontSize = Number(localStorage.getItem('librum_fontSize')) || 17;
-    const savedLineSpacing = Number(localStorage.getItem('librum_lineSpacing')) || 1.9;
-
-    setTheme(savedTheme);
-    setFontSize(savedFontSize);
-    setLineSpacing(savedLineSpacing);
-    setContentStyle(applyTheme(savedTheme, savedFontSize, savedLineSpacing));
-  }, []);
+  // Fix lint: inicializa a partir do localStorage diretamente no useState (sem useEffect)
+  const [theme, setTheme] = useState(() => localStorage.getItem('librum_theme') || 'padrao');
+  const [fontSize, setFontSize] = useState(() => Number(localStorage.getItem('librum_fontSize')) || 17);
+  const [lineSpacing, setLineSpacing] = useState(() => Number(localStorage.getItem('librum_lineSpacing')) || 1.9);
+  const [contentStyle, setContentStyle] = useState(() =>
+    applyTheme(
+      localStorage.getItem('librum_theme') || 'padrao',
+      Number(localStorage.getItem('librum_fontSize')) || 17,
+      Number(localStorage.getItem('librum_lineSpacing')) || 1.9
+    )
+  );
 
   useEffect(() => {
     const loadContent = async () => {
       setLoading(true);
-      const data = await ReadingService.getSegmentContent(phaseId, segmentNumber);
-      setContent(data);
-      setLoading(false);
+      setErro(false);
+      try {
+        const data = await ReadingService.getSegmentContent(phaseId, segmentNumber);
+        setContent(data);
+      } catch (e) {
+        console.error(e);
+        setErro(true);
+      } finally {
+        setLoading(false);
+      }
     };
     loadContent();
   }, [phaseId, segmentNumber]);
@@ -61,8 +65,11 @@ export default function ReadingPage() {
   };
 
   const handleNext = async () => {
-    await ReadingService.markProgress(phaseId, segmentNumber);
-
+    try {
+      await ReadingService.markProgress(phaseId, segmentNumber);
+    } catch (e) {
+      console.error(e);
+    }
     if (Number(segmentNumber) >= content.totalSegments) {
       navigate(`/quiz/${phaseId}`);
     } else {
@@ -70,7 +77,8 @@ export default function ReadingPage() {
     }
   };
 
-  if (loading || !content) return <div>Carregando trecho...</div>;
+  if (loading) return <div>Carregando trecho...</div>;
+  if (erro || !content) return <div>Não foi possível carregar o trecho.</div>;
 
   const paragraphs = content.content.split('\n').filter(p => p.trim() !== '');
 
@@ -78,10 +86,10 @@ export default function ReadingPage() {
     <div className="reading-container">
       <header className="reading-header">
         <div className="header-left">
-          <button onClick={() => navigate(`/genres/${content?.genreSlug || 'aventura'}`)} className="btn-logo">
+          <button onClick={() => navigate('/genres')} className="btn-logo">
             <img src={logoLivro} alt="Logo Librum" style={{ width: '56px', height: '56px', objectFit: 'contain', padding: '0px' }} />
           </button>
-          <span className="breadcrumb">← <span className="highlight">{content?.bookTitle || 'A Ilha do Tesouro'}</span> · Fase {phaseId}</span>
+          <span className="breadcrumb">← <span className="highlight">{content?.bookTitle}</span> · Fase {phaseId}</span>
         </div>
         <div className="header-center">
           Trecho {segmentNumber} de {content.totalSegments}
@@ -103,7 +111,7 @@ export default function ReadingPage() {
           </div>
           <div className="sidebar-section">
             <div className="label">GÊNERO</div>
-            <div className="value highlight">⛵ {content.genreName}</div>
+            <div className="value highlight">{content.genreName}</div>
           </div>
           <div className="sidebar-section">
             <div className="label">TEMPO ESTIMADO</div>
@@ -165,7 +173,7 @@ export default function ReadingPage() {
               </label>
             </div>
 
-            <p className="save-status">✓ preferências salvas no perfil</p>
+            <p className="save-status">Preferências salvas neste dispositivo</p>
           </div>
         </aside>
       </div>

--- a/frontend/src/pages/ReadingPage.jsx
+++ b/frontend/src/pages/ReadingPage.jsx
@@ -7,6 +7,8 @@ import mascote from '../assets/librum-mascote-principal.png';
 import logoLivro from '../assets/logo-livro.png';
 import XpBadge from '../components/XpBadge';
 import '../components/XpBadge.css';
+import LoadingState from '../components/ui/LoadingState';
+import ErrorState from '../components/ui/ErrorState';
 
 export default function ReadingPage() {
   const { phaseId, segmentNumber } = useParams();
@@ -77,8 +79,8 @@ export default function ReadingPage() {
     }
   };
 
-  if (loading) return <div>Carregando trecho...</div>;
-  if (erro || !content) return <div>Não foi possível carregar o trecho.</div>;
+  if (loading) return <LoadingState message="Carregando trecho..." />;
+  if (erro || !content) return <ErrorState message="Não foi possível carregar o trecho." />;
 
   const paragraphs = content.content.split('\n').filter(p => p.trim() !== '');
 

--- a/frontend/src/services/ReadingService.js
+++ b/frontend/src/services/ReadingService.js
@@ -4,69 +4,31 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 export const ReadingService = {
   getPhases: async (genreId) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/genres/${genreId}/phases`, {
-        headers: { ...authHeader() }
-      });
-      if (!response.ok) throw new Error('Failed to fetch phases');
-      return await response.json();
-    } catch (error) {
-      console.error(error);
-      return [
-        { id: 1, phaseNumber: 1, name: 'Fase 1', isUnlocked: true, isCompleted: true },
-        { id: 2, phaseNumber: 2, name: 'Fase 2', isUnlocked: true, isCompleted: true },
-        { id: 3, phaseNumber: 3, name: 'Fase 3', isUnlocked: true, isCompleted: false },
-        { id: 4, phaseNumber: 4, name: 'Fase 4', isUnlocked: false, isCompleted: false },
-        { id: 5, phaseNumber: 5, name: 'Fase 5', isUnlocked: false, isCompleted: false },
-        { id: 6, phaseNumber: 6, name: 'Fase 6', isUnlocked: false, isCompleted: false },
-        { id: 7, phaseNumber: 7, name: 'Fase 7', isUnlocked: false, isCompleted: false },
-        { id: 8, phaseNumber: 8, name: 'Fase 8', isUnlocked: false, isCompleted: false },
-      ];
-    }
+    const response = await fetch(`${API_BASE_URL}/genres/${genreId}/phases`, {
+      headers: { ...authHeader() }
+    });
+    if (!response.ok) throw new Error('Falha ao carregar as fases');
+    return await response.json();
   },
 
   getSegmentContent: async (phaseId, segmentNumber) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/reading/${phaseId}/${segmentNumber}`, {
-        headers: { ...authHeader() }
-      });
-      if (!response.ok) throw new Error('Failed to fetch segment content');
-      return await response.json();
-    } catch (error) {
-      console.error(error);
-      return {
-        phaseId,
-        segmentNumber,
-        totalSegments: 4,
-        bookTitle: 'A Ilha do Tesouro, Cap. III',
-        genreName: 'Aventura',
-        estimatedMinutes: 3,
-        content: `O sol havia mergulhado além do horizonte quando Jim avistou, pela primeira vez, a silhueta recortada das montanhas da ilha. Uma névoa fina cobria o ancoradouro, e o cheiro de maresia misturava-se ao carvão da fumaça que saía da chaminé do Hispaniola.
-
-— Esta é a ilha? — perguntou ele ao capitão Smollett, tentando disfarçar o tremor na voz. O capitão assentiu sem tirar os olhos da bússola, e Jim sentiu o coração bater mais forte dentro do peito.
-
-Havia segredos escondidos naquela terra. Segredos enterrados fundo, marcados com uma cruz vermelha num mapa manchado de sal e sangue. Jim apertou o papel dentro do casaco e respirou fundo, tentando se lembrar por que havia embarcado nessa aventura.
-
-Ao longe, entre as palmeiras, algo se movia. Uma sombra que não deveria estar ali — rápida demais para ser um animal, silenciosa demais para ser inocente.`
-      };
-    }
+    const response = await fetch(`${API_BASE_URL}/reading/${phaseId}/${segmentNumber}`, {
+      headers: { ...authHeader() }
+    });
+    if (!response.ok) throw new Error('Falha ao carregar o trecho');
+    return await response.json();
   },
 
   markProgress: async (phaseId, segmentNumber) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/progress/mark-read`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...authHeader()
-        },
-        body: JSON.stringify({ phaseId, segmentNumber }),
-      });
-      if (!response.ok) throw new Error('Failed to mark progress');
-      return await response.json();
-    } catch (error) {
-      console.error(error);
-      return { success: true };
-    }
+    const response = await fetch(`${API_BASE_URL}/progress/mark-read`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeader()
+      },
+      body: JSON.stringify({ phaseId, segmentNumber }),
+    });
+    if (!response.ok) throw new Error('Falha ao salvar o progresso');
+    return await response.json();
   }
 };

--- a/frontend/src/utils/readingThemes.js
+++ b/frontend/src/utils/readingThemes.js
@@ -4,7 +4,6 @@ export const themes = {
     label: 'Padrão',
     contentBackground: '#FAF8F5',
     contentColor: '#333333',
-    fontFamily: 'Georgia, serif',
     dropCapColor: '#F97316',
     sidebarBg: '#FFFFFF',
     controlsBg: '#FFFFFF'
@@ -14,7 +13,6 @@ export const themes = {
     label: 'Noturno',
     contentBackground: '#1E1E2E',
     contentColor: '#CDCDD6',
-    fontFamily: 'Georgia, serif',
     dropCapColor: '#FBAF7B',
     sidebarBg: '#2A2A3C',
     controlsBg: '#2A2A3C'
@@ -24,7 +22,6 @@ export const themes = {
     label: 'Ampliado',
     contentBackground: '#FAF8F5',
     contentColor: '#000000',
-    fontFamily: 'Georgia, serif',
     dropCapColor: '#D9530F',
     sidebarBg: '#FFFFFF',
     controlsBg: '#FFFFFF'
@@ -44,7 +41,6 @@ export const applyTheme = (themeId, fontSize, lineSpacing) => {
   return {
     backgroundColor: theme.contentBackground,
     color: theme.contentColor,
-    fontFamily: theme.fontFamily,
     fontSize: `${fontSize}px`,
     lineHeight: lineSpacing,
   };


### PR DESCRIPTION
Descrição

> Reestiliza a trilha de fases e a leitura com o design system, reconstrói a trilha com nós de fase (bloqueada, ativa, concluída), remove o título e o autor hardcoded da PhaseListPage e o mock enganoso do ReadingService, e corrige o texto de preferências de leitura.
> Por quê: a trilha e a leitura usavam estilos próprios e dados fixos, e o mock fingia progresso, podendo levar o usuário novo à fase errada.

Closes #126 
Closes #66 
Closes #67 

---
Tipo de Mudança

- [ ] Nova funcionalidade
- [ ] Correção de bug
- [x] Melhoria de código
- [ ] Documentação
- [ ] Testes
- [ ] Configuração/infraestrutura

---
Como Testar

1. Garantir que o design system (M1) está na main
2. Rodar npm run dev, autenticar e abrir a trilha de um gênero
3. Conferir o título e o autor vindos do backend, a barra de progresso e os nós de fase
4. Conferir que fases bloqueadas não abrem e que a fase ativa abre a leitura
5. Na leitura, conferir a fonte de leitura no texto e o texto de preferências corrigido
6. Com o backend desligado, conferir que aparece estado de erro, sem fingir progresso
7. Rodar npm run lint e confirmar que o ReadingPage.jsx não acusa erro

Resultado esperado: trilha e leitura com a identidade visual, sem hardcode, sem mock enganoso e sem erro de lint.

---
Checklist

- [ ] Código compila e executa sem erros
- [ ] Testes adicionados/atualizados e passando
- [ ] Padrões de código seguidos (lint/formatação)
- [x] Commits seguem Conventional Commits
- [ ] Branch atualizada com main
