### PR TITLE
Feat/progresso e perfil

### DIFF
--- a/backend/src/main/java/com/librum/controller/UserController.java
+++ b/backend/src/main/java/com/librum/controller/UserController.java
@@ -1,8 +1,10 @@
 package com.librum.controller;
 
 import com.librum.dto.UserProfileResponse;
+import com.librum.dto.UserProgressSummaryResponse;
 import com.librum.model.User;
 import com.librum.repository.UserRepository;
+import com.librum.service.ProgressSummaryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,9 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserRepository userRepository;
+    private final ProgressSummaryService progressSummaryService;
 
-    public UserController(UserRepository userRepository) {
+    public UserController(UserRepository userRepository, ProgressSummaryService progressSummaryService) {
         this.userRepository = userRepository;
+        this.progressSummaryService = progressSummaryService;
     }
 
     @GetMapping("/me")
@@ -29,5 +33,11 @@ public class UserController {
                 user.getXp(),
                 user.getLevel()
         ));
+    }
+
+    @GetMapping("/me/progress")
+    public ResponseEntity<UserProgressSummaryResponse> getProgress(@AuthenticationPrincipal String email) {
+        User user = userRepository.findByEmail(email).orElseThrow();
+        return ResponseEntity.ok(progressSummaryService.getSummary(user.getId()));
     }
 }

--- a/backend/src/main/java/com/librum/dto/UserProgressSummaryResponse.java
+++ b/backend/src/main/java/com/librum/dto/UserProgressSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.librum.dto;
+
+import java.util.List;
+
+public record UserProgressSummaryResponse(
+        int xp,
+        int level,
+        int totalCompletedPhases,
+        List<GenreProgress> byGenre
+) {
+    public record GenreProgress(
+            Long genreId,
+            String genreName,
+            String slug,
+            int completedPhases,
+            int totalPhases
+    ) {}
+}

--- a/backend/src/main/java/com/librum/repository/UserProgressRepository.java
+++ b/backend/src/main/java/com/librum/repository/UserProgressRepository.java
@@ -2,7 +2,10 @@ package com.librum.repository;
 
 import com.librum.model.UserProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +13,7 @@ public interface UserProgressRepository extends JpaRepository<UserProgress, Long
     Optional<UserProgress> findByUserIdAndPhaseId(UUID userId, Long phaseId);
     boolean existsByUserIdAndPhaseIdAndIsCompletedTrue(UUID userId, Long phaseId);
     boolean existsByUserIdAndPhaseIdAndQuizCompletedTrue(UUID userId, Long phaseId);
+
+    @Query("SELECT up.phase.id FROM UserProgress up WHERE up.user.id = :userId AND up.quizCompleted = true")
+    List<Long> findPhaseIdsByUserIdAndQuizCompletedTrue(@Param("userId") UUID userId);
 }

--- a/backend/src/main/java/com/librum/service/ProgressSummaryService.java
+++ b/backend/src/main/java/com/librum/service/ProgressSummaryService.java
@@ -1,0 +1,70 @@
+package com.librum.service;
+
+import com.librum.dto.UserProgressSummaryResponse;
+import com.librum.model.Book;
+import com.librum.model.Genre;
+import com.librum.model.Phase;
+import com.librum.model.User;
+import com.librum.repository.BookRepository;
+import com.librum.repository.GenreRepository;
+import com.librum.repository.PhaseRepository;
+import com.librum.repository.UserProgressRepository;
+import com.librum.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class ProgressSummaryService {
+
+    private final UserRepository userRepository;
+    private final GenreRepository genreRepository;
+    private final BookRepository bookRepository;
+    private final PhaseRepository phaseRepository;
+    private final UserProgressRepository userProgressRepository;
+
+    public ProgressSummaryService(UserRepository userRepository,
+                                  GenreRepository genreRepository,
+                                  BookRepository bookRepository,
+                                  PhaseRepository phaseRepository,
+                                  UserProgressRepository userProgressRepository) {
+        this.userRepository = userRepository;
+        this.genreRepository = genreRepository;
+        this.bookRepository = bookRepository;
+        this.phaseRepository = phaseRepository;
+        this.userProgressRepository = userProgressRepository;
+    }
+
+    public UserProgressSummaryResponse getSummary(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("Usuario nao encontrado"));
+
+        List<UserProgressSummaryResponse.GenreProgress> byGenre = new ArrayList<>();
+        int totalCompleted = 0;
+
+        for (Genre genre : genreRepository.findAll()) {
+            Book book = bookRepository.findByGenreId(genre.getId()).orElse(null);
+            int completed = 0;
+            int total = 0;
+
+            if (book != null) {
+                List<Phase> phases = phaseRepository.findByBookIdOrderByPhaseNumber(book.getId());
+                total = phases.size();
+                for (Phase phase : phases) {
+                    if (userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, phase.getId())) {
+                        completed++;
+                    }
+                }
+            }
+
+            totalCompleted += completed;
+            byGenre.add(new UserProgressSummaryResponse.GenreProgress(
+                    genre.getId(), genre.getName(), genre.getSlug(), completed, total));
+        }
+
+        return new UserProgressSummaryResponse(user.getXp(), user.getLevel(), totalCompleted, byGenre);
+    }
+}

--- a/backend/src/main/java/com/librum/service/ProgressSummaryService.java
+++ b/backend/src/main/java/com/librum/service/ProgressSummaryService.java
@@ -14,7 +14,9 @@ import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -42,6 +44,10 @@ public class ProgressSummaryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("Usuario nao encontrado"));
 
+        Set<Long> phasesConcluidasIds = new HashSet<>(
+                userProgressRepository.findPhaseIdsByUserIdAndQuizCompletedTrue(userId)
+        );
+
         List<UserProgressSummaryResponse.GenreProgress> byGenre = new ArrayList<>();
         int totalCompleted = 0;
 
@@ -54,7 +60,7 @@ public class ProgressSummaryService {
                 List<Phase> phases = phaseRepository.findByBookIdOrderByPhaseNumber(book.getId());
                 total = phases.size();
                 for (Phase phase : phases) {
-                    if (userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, phase.getId())) {
+                    if (phasesConcluidasIds.contains(phase.getId())) {
                         completed++;
                     }
                 }

--- a/backend/src/test/java/com/librum/service/ProgressSummaryServiceTest.java
+++ b/backend/src/test/java/com/librum/service/ProgressSummaryServiceTest.java
@@ -1,0 +1,103 @@
+package com.librum.service;
+
+import com.librum.dto.UserProgressSummaryResponse;
+import com.librum.model.Book;
+import com.librum.model.Genre;
+import com.librum.model.Phase;
+import com.librum.model.User;
+import com.librum.repository.BookRepository;
+import com.librum.repository.GenreRepository;
+import com.librum.repository.PhaseRepository;
+import com.librum.repository.UserProgressRepository;
+import com.librum.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProgressSummaryServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private GenreRepository genreRepository;
+    @Mock private BookRepository bookRepository;
+    @Mock private PhaseRepository phaseRepository;
+    @Mock private UserProgressRepository userProgressRepository;
+
+    @InjectMocks private ProgressSummaryService progressSummaryService;
+
+    @Test
+    void getSummary_contaFasesConcluidasPorGenero() {
+        UUID userId = UUID.randomUUID();
+
+        User user = new User();
+        user.setId(userId);
+        user.setXp(60);
+        user.setLevel(2);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        Genre aventura = mock(Genre.class);
+        when(aventura.getId()).thenReturn(1L);
+        when(aventura.getName()).thenReturn("Aventura");
+        when(aventura.getSlug()).thenReturn("aventura");
+        when(genreRepository.findAll()).thenReturn(List.of(aventura));
+
+        Book book = mock(Book.class);
+        when(book.getId()).thenReturn(10L);
+        when(bookRepository.findByGenreId(1L)).thenReturn(Optional.of(book));
+
+        Phase fase1 = mock(Phase.class);
+        when(fase1.getId()).thenReturn(1L);
+        Phase fase2 = mock(Phase.class);
+        when(fase2.getId()).thenReturn(2L);
+        when(phaseRepository.findByBookIdOrderByPhaseNumber(10L)).thenReturn(List.of(fase1, fase2));
+
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 1L)).thenReturn(true);
+        when(userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 2L)).thenReturn(false);
+
+        UserProgressSummaryResponse resposta = progressSummaryService.getSummary(userId);
+
+        assertThat(resposta.xp()).isEqualTo(60);
+        assertThat(resposta.level()).isEqualTo(2);
+        assertThat(resposta.totalCompletedPhases()).isEqualTo(1);
+        assertThat(resposta.byGenre()).hasSize(1);
+        assertThat(resposta.byGenre().get(0).completedPhases()).isEqualTo(1);
+        assertThat(resposta.byGenre().get(0).totalPhases()).isEqualTo(2);
+    }
+
+    @Test
+    void getSummary_generoSemLivro_contaZero() {
+        UUID userId = UUID.randomUUID();
+
+        User user = new User();
+        user.setId(userId);
+        user.setXp(0);
+        user.setLevel(1);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        Genre romance = mock(Genre.class);
+        when(romance.getId()).thenReturn(2L);
+        when(romance.getName()).thenReturn("Romance");
+        when(romance.getSlug()).thenReturn("romance");
+        when(genreRepository.findAll()).thenReturn(List.of(romance));
+
+        when(bookRepository.findByGenreId(2L)).thenReturn(Optional.empty());
+
+        UserProgressSummaryResponse resposta = progressSummaryService.getSummary(userId);
+
+        assertThat(resposta.totalCompletedPhases()).isEqualTo(0);
+        assertThat(resposta.byGenre().get(0).completedPhases()).isEqualTo(0);
+        assertThat(resposta.byGenre().get(0).totalPhases()).isEqualTo(0);
+    }
+}

--- a/backend/src/test/java/com/librum/service/ProgressSummaryServiceTest.java
+++ b/backend/src/test/java/com/librum/service/ProgressSummaryServiceTest.java
@@ -63,8 +63,8 @@ class ProgressSummaryServiceTest {
         when(fase2.getId()).thenReturn(2L);
         when(phaseRepository.findByBookIdOrderByPhaseNumber(10L)).thenReturn(List.of(fase1, fase2));
 
-        when(userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 1L)).thenReturn(true);
-        when(userProgressRepository.existsByUserIdAndPhaseIdAndQuizCompletedTrue(userId, 2L)).thenReturn(false);
+        when(userProgressRepository.findPhaseIdsByUserIdAndQuizCompletedTrue(userId))
+                .thenReturn(List.of(1L));
 
         UserProgressSummaryResponse resposta = progressSummaryService.getSummary(userId);
 
@@ -93,6 +93,8 @@ class ProgressSummaryServiceTest {
         when(genreRepository.findAll()).thenReturn(List.of(romance));
 
         when(bookRepository.findByGenreId(2L)).thenReturn(Optional.empty());
+        when(userProgressRepository.findPhaseIdsByUserIdAndQuizCompletedTrue(userId))
+                .thenReturn(List.of());
 
         UserProgressSummaryResponse resposta = progressSummaryService.getSummary(userId);
 

--- a/docs/contrato-api-quiz.md
+++ b/docs/contrato-api-quiz.md
@@ -148,3 +148,39 @@ Retorna o perfil do usuário autenticado com XP e nível atual.
 - `level` (int): nível atual entre 1 e 10.
 
 **Resposta 401:** token ausente ou inválido.
+
+---
+
+## GET /users/me/progress
+
+Retorna o resumo de progresso do usuário autenticado, agregado por gênero. Usado pela página de Perfil e pela Home para exibir XP, nível e fases concluídas.
+
+**Autenticação:** `Authorization: Bearer <token>` (obrigatório).
+
+**Resposta 200:**
+
+```json
+{
+  "xp": 60,
+  "level": 2,
+  "totalCompletedPhases": 3,
+  "byGenre": [
+    {
+      "genreId": 1,
+      "genreName": "Aventura",
+      "slug": "aventura",
+      "completedPhases": 3,
+      "totalPhases": 7
+    }
+  ]
+}
+```
+
+- `xp` (int): XP acumulado total do usuário.
+- `level` (int): nível atual entre 1 e 10.
+- `totalCompletedPhases` (int): total de fases concluídas em todos os gêneros.
+- `byGenre` (lista): progresso por gênero. Inclui todos os gêneros cadastrados, mesmo os sem livro (nesses casos `completedPhases` e `totalPhases` são 0).
+- `completedPhases` (int): fases cujo quiz foi concluído naquele gênero.
+- `totalPhases` (int): total de fases do livro do gênero.
+
+**Resposta 401:** token ausente ou inválido.

--- a/frontend/src/pages/ProfilePage.css
+++ b/frontend/src/pages/ProfilePage.css
@@ -1,0 +1,148 @@
+.profile-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.profile-state {
+  padding: 3rem;
+  text-align: center;
+  color: var(--color-text-muted, #6b6375);
+}
+
+.profile-header {
+  background: var(--color-primary, #3a2f80);
+  color: #fff;
+  border-radius: var(--radius-lg, 22px);
+  padding: 2rem;
+}
+
+.profile-identity {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.profile-avatar {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--color-accent, #e8742a);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.profile-header h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.6rem;
+}
+
+.profile-header p {
+  margin: 0 0 0.5rem;
+  opacity: 0.85;
+  font-size: 0.95rem;
+}
+
+.profile-xp-bar {
+  height: 8px;
+  width: 240px;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.profile-xp-fill {
+  height: 100%;
+  background: var(--color-accent, #e8742a);
+}
+
+.profile-cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+.profile-card {
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #e7e2d6);
+  border-radius: var(--radius-md, 14px);
+  padding: 1.5rem;
+}
+
+.profile-card h2 {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+}
+
+.profile-row {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--color-border, #e7e2d6);
+  font-size: 0.95rem;
+}
+
+.profile-row:last-child {
+  border-bottom: none;
+}
+
+.profile-genres {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-genre-top {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  margin-bottom: 0.35rem;
+}
+
+.profile-genre-bar {
+  height: 8px;
+  background: var(--color-border, #e7e2d6);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.profile-genre-fill {
+  height: 100%;
+  background: var(--color-accent, #e8742a);
+}
+
+.profile-logout {
+  align-self: stretch;
+  padding: 0.9rem;
+  background: transparent;
+  border: 1.5px solid var(--color-danger, #c2483d);
+  color: var(--color-danger, #c2483d);
+  border-radius: var(--radius-md, 14px);
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.profile-logout:hover {
+  background: var(--color-danger, #c2483d);
+  color: #fff;
+}
+
+@media (max-width: 720px) {
+  .profile-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-xp-bar {
+    width: 100%;
+    max-width: 240px;
+  }
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import { authHeader } from '../utils/auth';
+import './ProfilePage.css';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+const niveis = {
+  1: 'Aprendiz',
+  2: 'Leitor',
+  3: 'Cronista',
+  4: 'Guardião das Histórias'
+};
+
+export default function ProfilePage() {
+  const navigate = useNavigate();
+  const { logoutUser } = useAuth();
+  const [perfil, setPerfil] = useState(null);
+  const [progresso, setProgresso] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState(false);
+
+  useEffect(() => {
+    const carregar = async () => {
+      try {
+        const respPerfil = await fetch(`${API_BASE_URL}/users/me`, { headers: { ...authHeader() } });
+        const respProgresso = await fetch(`${API_BASE_URL}/users/me/progress`, { headers: { ...authHeader() } });
+        if (!respPerfil.ok || !respProgresso.ok) throw new Error('Falha ao carregar perfil');
+        setPerfil(await respPerfil.json());
+        setProgresso(await respProgresso.json());
+      } catch (e) {
+        console.error(e);
+        setErro(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+    carregar();
+  }, []);
+
+  const handleLogout = () => {
+    logoutUser();
+    navigate('/login');
+  };
+
+  if (loading) return <div className="profile-state">Carregando perfil...</div>;
+  if (erro || !perfil) return <div className="profile-state">Não foi possível carregar o perfil.</div>;
+
+  const titulo = niveis[perfil.level] || 'Leitor';
+  const xpNoNivel = perfil.xp % 50;
+  const progressoNivel = (xpNoNivel / 50) * 100;
+
+  return (
+    <div className="profile-page">
+      <div className="profile-header">
+        <div className="profile-identity">
+          <div className="profile-avatar">{perfil.name?.charAt(0).toUpperCase()}</div>
+          <div>
+            <h1>{perfil.name}</h1>
+            <p>Nível {perfil.level} - {titulo} - {perfil.xp} xp</p>
+            <div className="profile-xp-bar">
+              <div className="profile-xp-fill" style={{ width: `${progressoNivel}%` }} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="profile-cards">
+        <section className="profile-card">
+          <h2>Dados da conta</h2>
+          <div className="profile-row"><span>Nome</span><span>{perfil.name}</span></div>
+          <div className="profile-row"><span>E-mail</span><span>{perfil.email}</span></div>
+        </section>
+
+        <section className="profile-card">
+          <h2>Preferências de leitura</h2>
+          <div className="profile-row"><span>Fonte</span><span>{localStorage.getItem('librum_fontSize') || 17}px</span></div>
+          <div className="profile-row"><span>Espaçamento</span><span>{localStorage.getItem('librum_lineSpacing') || 1.9}</span></div>
+          <div className="profile-row"><span>Tema</span><span>{localStorage.getItem('librum_theme') || 'padrao'}</span></div>
+        </section>
+      </div>
+
+      <section className="profile-card">
+        <h2>Progresso por gênero</h2>
+        <div className="profile-genres">
+          {progresso?.byGenre?.map((g) => {
+            const pct = g.totalPhases > 0 ? Math.round((g.completedPhases / g.totalPhases) * 100) : 0;
+            return (
+              <div key={g.genreId} className="profile-genre">
+                <div className="profile-genre-top">
+                  <span>{g.genreName}</span>
+                  <span>{g.completedPhases} / {g.totalPhases} fases</span>
+                </div>
+                <div className="profile-genre-bar">
+                  <div className="profile-genre-fill" style={{ width: `${pct}%` }} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <button className="profile-logout" onClick={handleLogout}>Sair da conta</button>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfilePage.jsx
+++ b/frontend/src/pages/ProfilePage.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { authHeader } from '../utils/auth';
+import LoadingState from '../components/ui/LoadingState';
+import ErrorState from '../components/ui/ErrorState';
 import './ProfilePage.css';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
@@ -24,11 +26,17 @@ export default function ProfilePage() {
   useEffect(() => {
     const carregar = async () => {
       try {
-        const respPerfil = await fetch(`${API_BASE_URL}/users/me`, { headers: { ...authHeader() } });
-        const respProgresso = await fetch(`${API_BASE_URL}/users/me/progress`, { headers: { ...authHeader() } });
+        const [respPerfil, respProgresso] = await Promise.all([
+          fetch(`${API_BASE_URL}/users/me`, { headers: { ...authHeader() } }),
+          fetch(`${API_BASE_URL}/users/me/progress`, { headers: { ...authHeader() } }),
+        ]);
         if (!respPerfil.ok || !respProgresso.ok) throw new Error('Falha ao carregar perfil');
-        setPerfil(await respPerfil.json());
-        setProgresso(await respProgresso.json());
+        const [dadosPerfil, dadosProgresso] = await Promise.all([
+          respPerfil.json(),
+          respProgresso.json(),
+        ]);
+        setPerfil(dadosPerfil);
+        setProgresso(dadosProgresso);
       } catch (e) {
         console.error(e);
         setErro(true);
@@ -44,8 +52,8 @@ export default function ProfilePage() {
     navigate('/login');
   };
 
-  if (loading) return <div className="profile-state">Carregando perfil...</div>;
-  if (erro || !perfil) return <div className="profile-state">Não foi possível carregar o perfil.</div>;
+  if (loading) return <LoadingState message="Carregando perfil..." />;
+  if (erro || !perfil) return <ErrorState message="Não foi possível carregar o perfil." />;
 
   const titulo = niveis[perfil.level] || 'Leitor';
   const xpNoNivel = perfil.xp % 50;

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -9,6 +9,7 @@ import QuizResultPage from '../pages/QuizResultPage';
 import PhaseCompletedPage from '../pages/PhaseCompletedPage';
 import PrivateRoute from "./PrivateRoute";
 import Layout from '../components/Layout';
+import ProfilePage from '../pages/ProfilePage';
 
 export const AppRoutes = () => {
   return (
@@ -70,6 +71,17 @@ export const AppRoutes = () => {
             <PrivateRoute>
               <Layout>
                 <PhaseListPage />
+              </Layout>
+            </PrivateRoute>
+          }
+        />
+
+        <Route
+          path="/perfil"
+          element={
+            <PrivateRoute>
+              <Layout>
+                <ProfilePage />
               </Layout>
             </PrivateRoute>
           }


### PR DESCRIPTION
## Descrição
> Adiciona o endpoint GET /users/me/progress (xp, nível, total de fases concluídas e progresso por gênero) e a página de Perfil que consome esses dados, com dados da conta, preferências de leitura e progresso por gênero.
> Por que: a Home e a página de Perfil dos wireframes precisam do progresso agregado do usuário, que ainda não existia num único lugar.

  Closes #122

  ---
  ## Tipo de Mudança

  - [x] Nova funcionalidade
  - [ ] Correção de bug
  - [ ] Melhoria de código
  - [ ] Documentação
  - [x] Testes
  - [ ] Configuração/infraestrutura

  ---
  ## Como Testar

  1. Rodar `./mvnw test` no backend (ProgressSummaryServiceTest verde)
  2. Subir backend e frontend
  3. Autenticar, concluir o quiz de uma fase e abrir /perfil
  4. Conferir que o progresso por gênero mostra a fase concluída e que xp e nível batem com /users/me

  Resultado esperado: endpoint retornando o resumo de progresso e a página de Perfil exibindo os dados corretamente.

  ---
  ## Checklist

  - [ ] Código compila e executa sem erros
  - [x] Testes adicionados/atualizados e passando
  - [ ] Padrões de código seguidos (lint/formatação)
  - [x] Commits seguem Conventional Commits
  - [ ] Branch atualizada com main