### PR TITLE
feat(ui): reestiliza quiz e fase concluida e remove mock enganoso

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -122,6 +122,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -442,6 +443,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -490,33 +492,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1277,8 +1255,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1318,6 +1295,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1328,6 +1306,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1477,6 +1456,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1517,7 +1497,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1643,6 +1622,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1910,8 +1890,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2028,6 +2007,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3066,7 +3046,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3308,6 +3287,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3360,7 +3340,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3376,7 +3355,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3408,6 +3386,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3417,6 +3396,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3429,8 +3409,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "7.14.2",
@@ -3848,6 +3827,7 @@
       "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4144,6 +4124,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/pages/PhaseCompletedPage.css
+++ b/frontend/src/pages/PhaseCompletedPage.css
@@ -3,13 +3,13 @@
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background: linear-gradient(145deg, #3A2F80 0%, #4B3FA0 100%);
+  background: linear-gradient(145deg, var(--color-primary) 0%, var(--color-primary-300) 100%);
   padding: 2rem;
   box-sizing: border-box;
 }
 
 .phase-completed-card {
-  background: #ffffff;
+  background: var(--color-surface);
   border-radius: 16px;
   box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
   padding: 3rem 2.5rem;
@@ -24,7 +24,7 @@
 }
 
 .phase-completed-badge {
-  background: #F97316;
+  background: var(--color-accent);
   color: white;
   padding: 0.5rem 1.5rem;
   border-radius: 9999px;
@@ -35,26 +35,26 @@
 }
 
 .phase-completed-badge.error {
-  background: #dc2626;
+  background: var(--color-danger);
 }
 
 .phase-completed-title-error {
   font-size: 1.75rem;
   font-weight: 800;
-  color: #1f2937;
+  color: var(--color-text);
   margin: 0;
 }
 
 .phase-completed-text-error {
   font-size: 1rem;
-  color: #4b5563;
+  color: var(--color-text-muted);
   line-height: 1.6;
   margin: 0;
 }
 
 .phase-completed-text-error-sub {
   font-size: 0.875rem;
-  color: #6b7280;
+  color: var(--color-text-muted);
   line-height: 1.5;
   margin: 0;
 }
@@ -62,14 +62,14 @@
 .phase-completed-xp {
   font-size: 4rem;
   font-weight: 800;
-  color: #F97316;
+  color: var(--color-accent);
   line-height: 1;
 }
 
 .phase-completed-levelup {
-  background: #ecfdf5;
-  border: 1px solid #10b981;
-  color: #047857;
+  background: var(--color-success-bg);
+  border: 1px solid var(--color-success);
+  color: var(--color-success);
   padding: 0.75rem 1.5rem;
   border-radius: 8px;
   font-weight: 700;
@@ -84,8 +84,8 @@
 }
 
 .stat-box {
-  background: #FAF8F5;
-  border: 1px solid #eaeaea;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 1.25rem;
   flex: 1;
@@ -97,12 +97,12 @@
 .stat-value {
   font-size: 1.5rem;
   font-weight: 800;
-  color: #1f2937;
+  color: var(--color-text);
 }
 
 .stat-label {
   font-size: 0.72rem;
-  color: #666;
+  color: var(--color-text-muted);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.07em;
@@ -119,20 +119,20 @@
   display: flex;
   justify-content: space-between;
   font-size: 0.8rem;
-  color: #666;
+  color: var(--color-text-muted);
   font-weight: 600;
 }
 
 .phase-completed-progress-bar {
   height: 10px;
-  background: #eaeaea;
+  background: var(--color-border);
   border-radius: 9999px;
   overflow: hidden;
 }
 
 .phase-completed-progress-fill {
   height: 100%;
-  background: linear-gradient(90deg, #F97316, #ea580c);
+  background: linear-gradient(90deg, var(--color-accent), var(--color-accent-600));
   border-radius: 9999px;
   transition: width 1.5s cubic-bezier(0.22, 1, 0.36, 1);
 }
@@ -147,28 +147,28 @@
 .btn-phase-continue {
   width: 100%;
   padding: 1rem;
-  background: linear-gradient(135deg, #ea580c, #F97316);
+  background: linear-gradient(135deg, var(--color-accent-600), var(--color-accent));
   color: white;
   border: none;
   border-radius: 8px;
   font-weight: 700;
   font-size: 1rem;
   cursor: pointer;
-  box-shadow: 0 4px 14px rgba(249, 115, 22, 0.32);
+  box-shadow: 0 4px 14px rgba(232, 116, 42, 0.32);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .btn-phase-continue:hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(249, 115, 22, 0.44);
+  box-shadow: 0 6px 20px rgba(232, 116, 42, 0.44);
 }
 
 .btn-phase-secondary {
   width: 100%;
   padding: 0.875rem;
   background: transparent;
-  color: #666;
-  border: 1.5px solid #eaeaea;
+  color: var(--color-text-muted);
+  border: 1.5px solid var(--color-border);
   border-radius: 8px;
   font-weight: 600;
   font-size: 0.9rem;
@@ -177,6 +177,6 @@
 }
 
 .btn-phase-secondary:hover {
-  border-color: #666;
-  color: #333;
+  border-color: var(--color-text-muted);
+  color: var(--color-text);
 }

--- a/frontend/src/pages/PhaseCompletedPage.css
+++ b/frontend/src/pages/PhaseCompletedPage.css
@@ -180,3 +180,9 @@
   border-color: var(--color-text-muted);
   color: var(--color-text);
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .phase-completed-progress-fill {
+    transition: none;
+  }
+}

--- a/frontend/src/pages/PhaseCompletedPage.jsx
+++ b/frontend/src/pages/PhaseCompletedPage.jsx
@@ -33,7 +33,7 @@ const PhaseCompletedPage = () => {
     if (hasNextPhase) {
       navigate(`/reading/${nextPhaseId}/1`);
     } else {
-      navigate(`/genres/${genreSlug || 'aventura'}`);
+      navigate('/genres');
     }
   };
 
@@ -85,7 +85,7 @@ const PhaseCompletedPage = () => {
               </button>
               <button
                 className="btn-phase-secondary"
-                onClick={() => navigate(`/genres/${genreSlug || 'aventura'}`)}
+                onClick={() => navigate('/genres')}
               >
                 Voltar ao início
               </button>
@@ -108,7 +108,7 @@ const PhaseCompletedPage = () => {
               </button>
               <button
                 className="btn-phase-secondary"
-                onClick={() => navigate(`/genres/${genreSlug || 'aventura'}`)}
+                onClick={() => navigate('/genres')}
               >
                 Voltar ao início
               </button>

--- a/frontend/src/pages/PhaseCompletedPage.jsx
+++ b/frontend/src/pages/PhaseCompletedPage.jsx
@@ -21,7 +21,6 @@ const PhaseCompletedPage = () => {
     newLevel = 1,
     leveledUp = false,
     nextPhaseId = null,
-    genreSlug = 'aventura',
     passed = false
   } = result;
 

--- a/frontend/src/pages/QuizPage.css
+++ b/frontend/src/pages/QuizPage.css
@@ -1,38 +1,85 @@
 .quiz-page {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   min-height: calc(100vh - 100px);
   background-color: var(--color-bg, #f9fafb);
   padding: 2rem;
 }
 
-.quiz-loading {
-  text-align: center;
-  font-size: 1.25rem;
-  color: var(--color-text, #374151);
-  margin-top: 4rem;
-}
-
 .quiz-container {
   width: 100%;
-  max-width: 800px;
+  max-width: 900px;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
 }
 
-.quiz-container h2 {
+.quiz-header {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.quiz-header h2 {
   font-size: 1.5rem;
   font-weight: 700;
   color: var(--color-text, #111827);
   text-align: center;
+  margin: 0;
+}
+
+.quiz-progress {
+  display: flex;
+  gap: 0.4rem;
+  justify-content: center;
+  width: 100%;
+  max-width: 320px;
+}
+
+.quiz-progress__seg {
+  height: 8px;
+  flex: 1;
+  border-radius: var(--radius-full, 999px);
+  background: var(--color-border, #e7e2d6);
+  transition: background 0.3s ease;
+}
+
+.quiz-progress__seg--current {
+  background: var(--color-accent, #e8742a);
+}
+
+.quiz-progress__seg--correct {
+  background: var(--color-success, #2e9e5b);
+}
+
+.quiz-progress__seg--incorrect {
+  background: var(--color-danger, #c2483d);
+}
+
+.quiz-body {
+  display: grid;
+  grid-template-columns: 1fr 180px;
+  gap: 2rem;
+  align-items: start;
+}
+
+.quiz-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.quiz-side {
+  position: sticky;
+  top: 2rem;
 }
 
 .quiz-card {
   background-color: var(--color-surface, #ffffff);
-  border-radius: 0.75rem;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  border-radius: var(--radius-md, 14px);
+  box-shadow: var(--shadow-sm, 0 1px 3px rgba(42,37,51,0.08));
   padding: 2rem;
   display: flex;
   flex-direction: column;
@@ -42,16 +89,18 @@
 .quiz-question-counter {
   font-size: 0.875rem;
   font-weight: 600;
-  color: var(--color-primary, #F97316);
+  color: var(--color-primary, #3a2f80);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  margin: 0;
 }
 
 .quiz-question-text {
-  font-size: 1.25rem;
+  font-size: 1.2rem;
   font-weight: 600;
   color: var(--color-text, #1f2937);
   line-height: 1.5;
+  margin: 0;
 }
 
 .quiz-options {
@@ -64,15 +113,15 @@
   display: flex;
   align-items: center;
   padding: 1rem;
-  border: 2px solid var(--color-border, #e5e7eb);
-  border-radius: 0.5rem;
+  border: 2px solid var(--color-border, #e7e2d6);
+  border-radius: var(--radius-sm, 8px);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
 .quiz-option:hover:not(.disabled) {
-  border-color: var(--color-border);
-  background-color: #f9fafb;
+  border-color: var(--color-primary-300, #6b5fb5);
+  background-color: var(--color-bg, #f7f3ea);
 }
 
 .quiz-option.selected {
@@ -105,6 +154,7 @@
   color: var(--color-text-muted);
   font-weight: 600;
   margin-right: 1rem;
+  flex-shrink: 0;
 }
 
 .quiz-option.selected .quiz-option-letter {
@@ -131,15 +181,15 @@
 .quiz-confirm-btn {
   background-color: var(--color-accent);
   color: #ffffff;
-  font-weight: 600;
+  font-weight: 700;
   font-size: 1rem;
   padding: 0.75rem 1.5rem;
   border: none;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-sm, 8px);
   cursor: pointer;
   transition: background-color 0.2s ease;
   align-self: flex-end;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
 }
 
 .quiz-confirm-btn:hover:not(:disabled) {
@@ -147,8 +197,59 @@
 }
 
 .quiz-confirm-btn:disabled {
-  background-color: #fdba74;
+  opacity: 0.5;
   cursor: not-allowed;
+}
+
+.quiz-reference {
+  border-radius: var(--radius-md, 14px);
+  padding: 1rem 1.25rem;
+  border-left: 4px solid;
+}
+
+.quiz-reference__label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+}
+
+.quiz-reference p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.quiz-reference--correct {
+  background: var(--color-success-bg);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.quiz-reference--incorrect {
+  background: #fef2f2;
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+}
+
+@media (max-width: 720px) {
+  .quiz-body {
+    grid-template-columns: 1fr;
+  }
+
+  .quiz-side {
+    position: static;
+    display: flex;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quiz-progress__seg {
+    transition: none;
+  }
 }
 
 .theme-dark .quiz-page {
@@ -160,14 +261,7 @@
   border: 1px solid #374151;
 }
 
-.theme-dark .quiz-container h2 {
-  color: #f9fafb;
-}
-
-.theme-dark .quiz-loading {
-  color: #f9fafb;
-}
-
+.theme-dark .quiz-header h2,
 .theme-dark .quiz-question-text {
   color: #f3f4f6;
 }
@@ -181,18 +275,15 @@
 }
 
 .theme-dark .quiz-option.selected {
-  background-color: rgba(249, 115, 22, 0.1);
-  border-color: #F97316;
+  background-color: rgba(232, 116, 42, 0.1);
 }
 
 .theme-dark .quiz-option.correct {
-  background-color: rgba(16, 185, 129, 0.1);
-  border-color: #10b981;
+  background-color: rgba(46, 158, 91, 0.1);
 }
 
 .theme-dark .quiz-option.incorrect {
-  background-color: rgba(239, 68, 68, 0.1);
-  border-color: #ef4444;
+  background-color: rgba(194, 72, 61, 0.1);
 }
 
 .theme-dark .quiz-option-letter {
@@ -202,42 +293,4 @@
 
 .theme-dark .quiz-option-text {
   color: #d1d5db;
-}
-
-.quiz-option.correct {
-  border-color: var(--color-success);
-  background: var(--color-success-bg);
-  color: var(--color-success);
-}
-
-.quiz-option.incorrect {
-  border-color: var(--color-danger);
-  background: #fef2f2;
-  color: var(--color-danger);
-}
-
-.quiz-explanation {
-  margin-top: 12px;
-  padding: 14px 16px;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  line-height: 1.5;
-  text-align: left;
-}
-
-.quiz-explanation.correct {
-  background: var(--color-success-bg);
-  border: 1px solid var(--color-success);
-  color: var(--color-success);
-}
-
-.quiz-explanation.incorrect {
-  background: #fef2f2;
-  border: 1px solid var(--color-danger);
-  color: var(--color-danger);
-}
-
-.quiz-explanation-label {
-  font-weight: 700;
-  margin-bottom: 4px;
 }

--- a/frontend/src/pages/QuizPage.css
+++ b/frontend/src/pages/QuizPage.css
@@ -3,7 +3,7 @@
   justify-content: center;
   align-items: center;
   min-height: calc(100vh - 100px);
-  background-color: var(--color-background, #f9fafb);
+  background-color: var(--color-bg, #f9fafb);
   padding: 2rem;
 }
 
@@ -71,22 +71,22 @@
 }
 
 .quiz-option:hover:not(.disabled) {
-  border-color: #d1d5db;
+  border-color: var(--color-border);
   background-color: #f9fafb;
 }
 
 .quiz-option.selected {
-  border-color: #F97316;
+  border-color: var(--color-accent);
   background-color: #fff7ed;
 }
 
 .quiz-option.correct {
-  border-color: #10b981;
-  background-color: #ecfdf5;
+  border-color: var(--color-success);
+  background-color: var(--color-success-bg);
 }
 
 .quiz-option.incorrect {
-  border-color: #ef4444;
+  border-color: var(--color-danger);
   background-color: #fef2f2;
 }
 
@@ -102,23 +102,23 @@
   height: 2rem;
   border-radius: 50%;
   background-color: #f3f4f6;
-  color: #4b5563;
+  color: var(--color-text-muted);
   font-weight: 600;
   margin-right: 1rem;
 }
 
 .quiz-option.selected .quiz-option-letter {
-  background-color: #F97316;
+  background-color: var(--color-accent);
   color: #ffffff;
 }
 
 .quiz-option.correct .quiz-option-letter {
-  background-color: #10b981;
+  background-color: var(--color-success);
   color: #ffffff;
 }
 
 .quiz-option.incorrect .quiz-option-letter {
-  background-color: #ef4444;
+  background-color: var(--color-danger);
   color: #ffffff;
 }
 
@@ -129,7 +129,7 @@
 }
 
 .quiz-confirm-btn {
-  background-color: #F97316;
+  background-color: var(--color-accent);
   color: #ffffff;
   font-weight: 600;
   font-size: 1rem;
@@ -143,7 +143,7 @@
 }
 
 .quiz-confirm-btn:hover:not(:disabled) {
-  background-color: #ea580c;
+  background-color: var(--color-accent-600);
 }
 
 .quiz-confirm-btn:disabled {
@@ -205,15 +205,15 @@
 }
 
 .quiz-option.correct {
-  border-color: #16a34a;
-  background: #f0fdf4;
-  color: #15803d;
+  border-color: var(--color-success);
+  background: var(--color-success-bg);
+  color: var(--color-success);
 }
 
 .quiz-option.incorrect {
-  border-color: #dc2626;
+  border-color: var(--color-danger);
   background: #fef2f2;
-  color: #b91c1c;
+  color: var(--color-danger);
 }
 
 .quiz-explanation {
@@ -226,15 +226,15 @@
 }
 
 .quiz-explanation.correct {
-  background: #f0fdf4;
-  border: 1px solid #86efac;
-  color: #166534;
+  background: var(--color-success-bg);
+  border: 1px solid var(--color-success);
+  color: var(--color-success);
 }
 
 .quiz-explanation.incorrect {
   background: #fef2f2;
-  border: 1px solid #fca5a5;
-  color: #991b1b;
+  border: 1px solid var(--color-danger);
+  color: var(--color-danger);
 }
 
 .quiz-explanation-label {

--- a/frontend/src/pages/QuizPage.jsx
+++ b/frontend/src/pages/QuizPage.jsx
@@ -1,13 +1,25 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { QuizService } from '../services/QuizService';
+import MascotBubble from '../components/ui/MascotBubble';
+import LoadingState from '../components/ui/LoadingState';
+import ErrorState from '../components/ui/ErrorState';
+import mascotePensativo from '../assets/librum-pensativo.png';
 import './QuizPage.css';
+
+const MASCOT_MESSAGES = {
+  idle: 'Leia com atenção antes de responder.',
+  correct: 'Muito bem! Você acertou!',
+  incorrect: 'Não desanime, releia o trecho.'
+};
 
 const QuizPage = () => {
   const { phaseId } = useParams();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState(false);
   const [answers, setAnswers] = useState([]);
+  const [results, setResults] = useState([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [selectedOption, setSelectedOption] = useState('');
   const [feedback, setFeedback] = useState(null);
@@ -21,7 +33,8 @@ const QuizPage = () => {
         const data = await QuizService.getQuizQuestions(phaseId);
         setQuestionsData(data);
       } catch (error) {
-        console.error("Erro ao carregar o quiz:", error);
+        console.error('Erro ao carregar o quiz:', error);
+        setErro(true);
       } finally {
         setLoading(false);
       }
@@ -29,15 +42,14 @@ const QuizPage = () => {
     fetchQuestions();
   }, [phaseId]);
 
-  if (loading) {
-    return <div className="quiz-loading">Carregando quiz...</div>;
-  }
-
+  if (loading) return <LoadingState message="Carregando quiz..." />;
+  if (erro) return <ErrorState message="Não foi possível carregar o quiz." />;
   if (!questionsData || questionsData.length === 0) {
-    return <div className="quiz-loading">Nenhuma questão encontrada para esta fase.</div>;
+    return <ErrorState message="Nenhuma questão encontrada para esta fase." />;
   }
 
   const currentQuestion = questionsData[currentQuestionIndex];
+  const mascotMessage = feedback ? MASCOT_MESSAGES[feedback] : MASCOT_MESSAGES.idle;
 
   const handleOptionChange = (e) => {
     if (feedback) return;
@@ -46,15 +58,10 @@ const QuizPage = () => {
 
   const handleConfirm = () => {
     if (!selectedOption) return;
-
     const isCorrect = selectedOption === currentQuestion.correctOption;
     setFeedback(isCorrect ? 'correct' : 'incorrect');
-
-    const newAnswer = {
-      questionId: currentQuestion.id,
-      selectedOption: selectedOption
-    };
-    setAnswers([...answers, newAnswer]);
+    setResults(prev => [...prev, isCorrect]);
+    setAnswers(prev => [...prev, { questionId: currentQuestion.id, selectedOption }]);
   };
 
   const handleNext = () => {
@@ -73,8 +80,8 @@ const QuizPage = () => {
       const result = await QuizService.submitQuiz(phaseId, finalAnswers);
       navigate(`/quiz/${phaseId}/fase-concluida`, { state: result });
     } catch (error) {
-      console.error("Erro ao enviar quiz:", error);
-      alert("Houve um erro ao enviar suas respostas.");
+      console.error('Erro ao enviar quiz:', error);
+      alert('Houve um erro ao enviar suas respostas.');
       setSubmitting(false);
     }
   };
@@ -82,70 +89,92 @@ const QuizPage = () => {
   return (
     <div className="quiz-page">
       <div className="quiz-container">
-        <h2>Quiz da Fase {phaseId}</h2>
-        <div className="quiz-card">
-          <p className="quiz-question-counter">Questão {currentQuestionIndex + 1} de {questionsData.length}</p>
-          <h3 className="quiz-question-text">{currentQuestion.questionText}</h3>
-
-          <div className="quiz-options">
-            {['A', 'B', 'C', 'D'].map((opt) => {
-              const isSelected = selectedOption === opt;
-              const isCorrect = currentQuestion.correctOption === opt;
-              let optionClass = '';
-              if (isSelected) optionClass += ' selected';
-              if (feedback) {
-                if (isCorrect) {
-                  optionClass += ' correct';
-                } else if (isSelected) {
-                  optionClass += ' incorrect';
-                }
+        <div className="quiz-header">
+          <h2>Quiz da Fase {phaseId}</h2>
+          <div className="quiz-progress">
+            {questionsData.map((_, i) => {
+              let cls = 'quiz-progress__seg';
+              if (i < results.length) {
+                cls += results[i] ? ' quiz-progress__seg--correct' : ' quiz-progress__seg--incorrect';
+              } else if (i === currentQuestionIndex) {
+                cls += ' quiz-progress__seg--current';
               }
-              return (
-                <label
-                  key={opt}
-                  className={`quiz-option${optionClass}`}
-                >
-                  <input
-                    type="radio"
-                    name="quiz-option"
-                    value={opt}
-                    checked={isSelected}
-                    onChange={handleOptionChange}
-                    disabled={feedback !== null}
-                  />
-                  <span className="quiz-option-letter">{opt}</span>
-                  <span className="quiz-option-text">{currentQuestion[`option${opt}`]}</span>
-                </label>
-              );
+              return <div key={i} className={cls} />;
             })}
           </div>
+        </div>
 
-          {feedback && (
-            <div className={`quiz-explanation ${feedback}`}>
-              <div className="quiz-explanation-label">
-                {feedback === 'correct' ? 'Correto!' : 'Errado.'}
+        <div className="quiz-body">
+          <div className="quiz-main">
+            <div className="quiz-card">
+              <p className="quiz-question-counter">
+                Questão {currentQuestionIndex + 1} de {questionsData.length}
+              </p>
+              <h3 className="quiz-question-text">{currentQuestion.questionText}</h3>
+
+              <div className="quiz-options">
+                {['A', 'B', 'C', 'D'].map((opt) => {
+                  const isSelected = selectedOption === opt;
+                  const isCorrect = currentQuestion.correctOption === opt;
+                  let optionClass = '';
+                  if (isSelected) optionClass += ' selected';
+                  if (feedback) {
+                    if (isCorrect) optionClass += ' correct';
+                    else if (isSelected) optionClass += ' incorrect';
+                  }
+                  return (
+                    <label key={opt} className={`quiz-option${optionClass}`}>
+                      <input
+                        type="radio"
+                        name="quiz-option"
+                        value={opt}
+                        checked={isSelected}
+                        onChange={handleOptionChange}
+                        disabled={feedback !== null}
+                      />
+                      <span className="quiz-option-letter">{opt}</span>
+                      <span className="quiz-option-text">{currentQuestion[`option${opt}`]}</span>
+                    </label>
+                  );
+                })}
               </div>
-              <p>{currentQuestion.explanation || 'Sem explicação disponível.'}</p>
-            </div>
-          )}
 
-          {feedback === null ? (
-            <button
-              className="quiz-confirm-btn"
-              onClick={handleConfirm}
-              disabled={!selectedOption || submitting}
-            >
-              {submitting ? 'Enviando...' : 'Confirmar'}
-            </button>
-          ) : (
-            <button
-              className="quiz-confirm-btn"
-              onClick={handleNext}
-              disabled={submitting}
-            >
-              {currentQuestionIndex < questionsData.length - 1 ? 'Próxima questão →' : 'Ver resultado →'}
-            </button>
-          )}
+              {feedback === null ? (
+                <button
+                  className="quiz-confirm-btn"
+                  onClick={handleConfirm}
+                  disabled={!selectedOption || submitting}
+                >
+                  Confirmar
+                </button>
+              ) : (
+                <button
+                  className="quiz-confirm-btn"
+                  onClick={handleNext}
+                  disabled={submitting}
+                >
+                  {currentQuestionIndex < questionsData.length - 1
+                    ? 'Próxima questão →'
+                    : 'Ver resultado →'}
+                </button>
+              )}
+            </div>
+
+            {feedback && (
+              <div className={`quiz-reference quiz-reference--${feedback}`}>
+                <span className="quiz-reference__label">Trecho de referência</span>
+                <p>{currentQuestion.explanation || 'Sem explicação disponível.'}</p>
+              </div>
+            )}
+          </div>
+
+          <div className="quiz-side">
+            <MascotBubble
+              src={mascotePensativo}
+              alt="Mascote Librum pensativo"
+              message={mascotMessage}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/services/QuizService.js
+++ b/frontend/src/services/QuizService.js
@@ -4,79 +4,23 @@ const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 export const QuizService = {
   getQuizQuestions: async (phaseId) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/quiz/${phaseId}`, {
-        headers: { ...authHeader() }
-      });
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.message || 'Failed to fetch quiz questions');
-      }
-      return await response.json();
-    } catch (error) {
-      console.error(error);
-      return [
-        {
-          id: 1,
-          phaseId: parseInt(phaseId),
-          questionText: "Qual era o nome do tesouro procurado por Jim Hawkins?",
-          optionA: "O Tesouro Perdido",
-          optionB: "O Tesouro do Flint",
-          optionC: "O Tesouro Enterrado",
-          optionD: "O Tesouro de Silver"
-        },
-        {
-          id: 2,
-          phaseId: parseInt(phaseId),
-          questionText: "Quem era o capitão Flint?",
-          optionA: "Um pirata lendário",
-          optionB: "O pai de Jim",
-          optionC: "Um marinheiro aposentado",
-          optionD: "O dono da Estalagem do Almirante Benbow"
-        },
-        {
-          id: 3,
-          phaseId: parseInt(phaseId),
-          questionText: "O que marcava o mapa do tesouro?",
-          optionA: "Um círculo negro",
-          optionB: "Uma cruz vermelha",
-          optionC: "Uma âncora",
-          optionD: "Uma caveira"
-        }
-      ];
-    }
+    const response = await fetch(`${API_BASE_URL}/quiz/${phaseId}`, {
+      headers: { ...authHeader() }
+    });
+    if (!response.ok) throw new Error('Falha ao carregar as questões');
+    return await response.json();
   },
 
   submitQuiz: async (phaseId, answers) => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/quiz/${phaseId}/submit`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...authHeader()
-        },
-        body: JSON.stringify({ answers })
-      });
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(errorData.message || 'Failed to submit quiz');
-      }
-      return await response.json();
-    } catch (error) {
-      console.error(error);
-      const totalQuestions = answers.length || 3;
-      const correctAnswers = totalQuestions;
-      const xpEarned = correctAnswers * 5;
-      return {
-        totalQuestions: totalQuestions,
-        correctAnswers: correctAnswers,
-        xpEarned: xpEarned,
-        newTotalXp: 45 + xpEarned,
-        newLevel: 1 + Math.floor((45 + xpEarned) / 50),
-        leveledUp: (45 + xpEarned) >= 50,
-        nextPhaseId: parseInt(phaseId) + 1,
-        passed: true
-      };
-    }
+    const response = await fetch(`${API_BASE_URL}/quiz/${phaseId}/submit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeader()
+      },
+      body: JSON.stringify({ answers })
+    });
+    if (!response.ok) throw new Error('Falha ao enviar o quiz');
+    return await response.json();
   }
 };


### PR DESCRIPTION
## Descrição

> Aplica o design system no quiz e na fase concluida, remove o mock do QuizService que sempre devolvia aprovado e sem correctOption, reconcilia o token de fundo do QuizPage.css e corrige a navegacao de voltar para a lista de generos.
> Por que: o quiz dependia de um mock enganoso e usava um token inexistente, e a fase concluida voltava por uma rota de slug que nao funciona.

Closes #130

---
Tipo de Mudanca

- [ ] Nova funcionalidade
- [ ] Correcao de bug
- [x] Melhoria de codigo
- [ ] Documentacao
- [ ] Testes
- [ ] Configuracao/infraestrutura

---
Como Testar

1. Garantir que o design system (M1) esta na main
2. Rodar npm run dev, ler uma fase e fazer o quiz
3. Conferir o feedback de correto e errado com a explicacao
4. Concluir o quiz e conferir a tela de fase concluida e o botao de continuar
5. Com mais de 2 erros, conferir a mensagem de reprovacao e o reler a fase
6. Com o backend desligado, conferir que aparece erro, sem fingir aprovacao

Resultado esperado: quiz e fase concluida com a identidade visual e sem mock enganoso.

---
Checklist

- [ ] Codigo compila e executa sem erros
- [ ] Testes adicionados/atualizados e passando
- [ ] Padroes de codigo seguidos (lint/formatacao)
- [x] Commits seguem Conventional Commits
- [ ] Branch atualizada com main