### PR TITLE
feat(ui): aplica identidade em auth e generos e cria home

### DIFF
--- a/frontend/src/components/AppShell.css
+++ b/frontend/src/components/AppShell.css
@@ -30,8 +30,8 @@
 }
 
 .sidebar__logo {
-  width: 32px;
-  height: 32px;
+  width: auto;
+  height: 40px;
   object-fit: contain;
 }
 

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -18,7 +18,6 @@ export default function Sidebar() {
     <aside className="sidebar">
       <div className="sidebar__brand">
         <img src={logo} alt="Librum" className="sidebar__logo" />
-        <span>Librum</span>
       </div>
 
       <nav className="sidebar__nav">

--- a/frontend/src/components/auth/LoginForm.jsx
+++ b/frontend/src/components/auth/LoginForm.jsx
@@ -16,7 +16,7 @@ const LoginForm = () => {
     try {
       const data = await login(credentials.email, credentials.password);
       loginUser(data);
-      navigate('/genres');
+      navigate('/inicio');
     } catch (err) {
       setError(err.message || 'E-mail ou senha incorretos');
     }

--- a/frontend/src/components/auth/RegisterForm.jsx
+++ b/frontend/src/components/auth/RegisterForm.jsx
@@ -26,7 +26,7 @@ const RegisterForm = () => {
     try {
       const response = await register(data.name, data.email, data.password);
       loginUser({ userId: response.userId, token: response.token });
-      navigate('/genres');
+      navigate('/inicio');
     } catch (err) {
       setError(err.message || 'Erro no cadastro');
     }

--- a/frontend/src/pages/GenresPage.css
+++ b/frontend/src/pages/GenresPage.css
@@ -1,119 +1,36 @@
-.genres-container {
-  padding: 40px;
-  max-width: 1200px;
+.genres-page {
+  max-width: 900px;
   margin: 0 auto;
-  font-family: 'Inter', sans-serif;
+  padding: 2rem 1.5rem;
 }
 
 .genres-header {
-  margin-bottom: 30px;
-}
-
-.genres-header h1 {
-  font-size: 2rem;
-  color: #333;
-  margin-bottom: 10px;
+  margin-bottom: 1.5rem;
 }
 
 .genres-header p {
-  color: #666;
-  font-size: 1rem;
+  color: var(--color-text-muted);
 }
 
 .genres-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.25rem;
 }
 
 .genre-card {
-  border: 1px solid #e0e0e0;
-  border-radius: 12px;
-  padding: 20px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
   display: flex;
   flex-direction: column;
-  position: relative;
-  background: white;
-  transition: transform 0.2s, box-shadow 0.2s;
+  gap: 0.75rem;
+  box-shadow: var(--shadow-sm);
 }
 
-.genre-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-}
-
-.genre-card.active {
-  border-color: #F97316;
-}
-
-.genre-card.disabled {
-  opacity: 0.7;
-  pointer-events: none;
-}
-
-.genre-card-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 15px;
-}
-
-.genre-icon {
-  font-size: 2rem;
-}
-
-.genre-badge {
-  background: #f0f0f0;
-  color: #666;
-  padding: 4px 8px;
-  border-radius: 12px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-}
-
-.genre-badge.active {
-  background: #fff3e0;
-  color: #F97316;
-}
-
-.genre-info h2 {
-  font-size: 1.25rem;
-  margin-bottom: 5px;
-  color: #333;
-}
-
-.genre-info p {
-  font-size: 0.875rem;
-  color: #666;
-  margin-bottom: 20px;
-}
-
-.genre-action {
-  margin-top: auto;
-}
-
-.btn-genre {
-  width: 100%;
-  padding: 10px;
-  border: none;
-  border-radius: 8px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s;
-}
-
-.btn-genre.active {
-  background-color: #F97316;
-  color: white;
-}
-
-.btn-genre.active:hover {
-  background-color: #ea580c;
-}
-
-.btn-genre.disabled {
-  background-color: #e0e0e0;
-  color: #999;
-  cursor: not-allowed;
+.genre-card__desc {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  flex: 1;
 }

--- a/frontend/src/pages/GenresPage.jsx
+++ b/frontend/src/pages/GenresPage.jsx
@@ -15,9 +15,7 @@ export default function GenresPage() {
   const [loading, setLoading] = useState(true);
   const [erro, setErro] = useState(false);
 
-  const carregar = async () => {
-    setLoading(true);
-    setErro(false);
+  const fetchDados = async () => {
     try {
       const response = await fetch(`${API_BASE_URL}/genres`, {
         headers: { ...authHeader() },
@@ -32,10 +30,16 @@ export default function GenresPage() {
     }
   };
 
-  useEffect(() => { carregar(); }, []);
+  useEffect(() => { fetchDados(); }, []);
+
+  const handleRetry = () => {
+    setLoading(true);
+    setErro(false);
+    fetchDados();
+  };
 
   if (loading) return <LoadingState message="Carregando generos..." />;
-  if (erro) return <ErrorState message="Nao foi possivel carregar os generos." onRetry={carregar} />;
+  if (erro) return <ErrorState message="Nao foi possivel carregar os generos." onRetry={handleRetry} />;
 
   return (
     <div className="genres-page">

--- a/frontend/src/pages/GenresPage.jsx
+++ b/frontend/src/pages/GenresPage.jsx
@@ -15,28 +15,33 @@ export default function GenresPage() {
   const [loading, setLoading] = useState(true);
   const [erro, setErro] = useState(false);
 
-  const fetchDados = async () => {
-    try {
-      const response = await fetch(`${API_BASE_URL}/genres`, {
-        headers: { ...authHeader() },
-      });
-      if (!response.ok) throw new Error('Falha ao carregar generos');
-      setGenres(await response.json());
-    } catch (e) {
-      console.error(e);
-      setErro(true);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const [retryCount, setRetryCount] = useState(0);
 
-  useEffect(() => { fetchDados(); }, []);
+  useEffect(() => {
+    const carregar = async () => {
+      try {
+        const response = await fetch(`${API_BASE_URL}/genres`, {
+          headers: { ...authHeader() },
+        });
+        if (!response.ok) throw new Error('Falha ao carregar generos');
+        setGenres(await response.json());
+      } catch (e) {
+        console.error(e);
+        setErro(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+    carregar();
+  }, [retryCount]);
 
   const handleRetry = () => {
     setLoading(true);
     setErro(false);
-    fetchDados();
+    setRetryCount(c => c + 1);
   };
+
+
 
   if (loading) return <LoadingState message="Carregando generos..." />;
   if (erro) return <ErrorState message="Nao foi possivel carregar os generos." onRetry={handleRetry} />;

--- a/frontend/src/pages/GenresPage.jsx
+++ b/frontend/src/pages/GenresPage.jsx
@@ -1,99 +1,60 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { authHeader } from '../utils/auth';
+import Button from '../components/ui/Button';
+import GenreBadge from '../components/ui/GenreBadge';
+import LoadingState from '../components/ui/LoadingState';
+import ErrorState from '../components/ui/ErrorState';
 import './GenresPage.css';
 
-const genres = [
-  {
-    id: 'aventura',
-    title: 'Aventura',
-    bookTitle: 'A Ilha do Tesouro',
-    author: 'Robert Louis Stevenson',
-    phases: 8,
-    active: true,
-    emoji: '⛵',
-  },
-  {
-    id: 'terror',
-    title: 'Terror',
-    bookTitle: 'O Médico e o Monstro',
-    author: 'Robert Louis Stevenson',
-    phases: 8,
-    active: false,
-    emoji: '🕷️',
-  },
-  {
-    id: 'fantasia',
-    title: 'Fantasia',
-    bookTitle: 'Dom Quixote (I)',
-    author: 'Miguel de Cervantes',
-    phases: 6,
-    active: false,
-    emoji: '✨',
-  },
-  {
-    id: 'romance',
-    title: 'Romance',
-    bookTitle: 'Orgulho e Preconceito',
-    author: 'Jane Austen',
-    phases: 8,
-    active: false,
-    emoji: '🌸',
-  },
-  {
-    id: 'suspense',
-    title: 'Suspense',
-    bookTitle: 'A definir',
-    author: 'A definir',
-    phases: 0,
-    active: false,
-    emoji: '🕵️',
-  }
-];
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
 
 export default function GenresPage() {
   const navigate = useNavigate();
+  const [genres, setGenres] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState(false);
 
-  const handleGenreClick = (genre) => {
-    if (genre.active) {
-      navigate(`/genres/${genre.id}`);
+  const carregar = async () => {
+    setLoading(true);
+    setErro(false);
+    try {
+      const response = await fetch(`${API_BASE_URL}/genres`, {
+        headers: { ...authHeader() },
+      });
+      if (!response.ok) throw new Error('Falha ao carregar generos');
+      setGenres(await response.json());
+    } catch (e) {
+      console.error(e);
+      setErro(true);
+    } finally {
+      setLoading(false);
     }
   };
 
+  useEffect(() => { carregar(); }, []);
+
+  if (loading) return <LoadingState message="Carregando generos..." />;
+  if (erro) return <ErrorState message="Nao foi possivel carregar os generos." onRetry={carregar} />;
+
   return (
-    <div className="genres-container">
-      <div className="genres-header">
-        <h1>Escolha um gênero para ler</h1>
-        <p>1 livro disponível por gênero · domínio público · sem custo</p>
-      </div>
+    <div className="genres-page">
+      <header className="genres-header">
+        <h1>Escolha um genero para ler</h1>
+        <p>Livros de dominio publico, sem custo</p>
+      </header>
 
       <div className="genres-grid">
-        {genres.map(genre => (
-          <div
-            key={genre.id}
-            className={`genre-card ${genre.active ? 'active' : 'disabled'}`}
-          >
-            <div className="genre-card-header">
-              <span className="genre-icon">{genre.emoji}</span>
-              <span className={`genre-badge ${genre.active ? 'active' : ''}`}>
-                {genre.active ? 'Em andamento' : 'Em breve'}
-              </span>
+        {genres.map((genre) => (
+          <article key={genre.id} className="genre-card">
+            <div className="genre-card__top">
+              <GenreBadge slug={genre.slug}>{genre.name}</GenreBadge>
             </div>
-
-            <div className="genre-info">
-              <h2>{genre.title}</h2>
-              <p>{genre.bookTitle}<br />{genre.author}{genre.phases > 0 ? ` · ${genre.phases} fases` : ''}</p>
-            </div>
-
-            <div className="genre-action">
-              <button
-                className={`btn-genre ${genre.active ? 'active' : 'disabled'}`}
-                onClick={() => handleGenreClick(genre)}
-                disabled={!genre.active}
-              >
-                {genre.active ? 'Continuar ▶' : 'Em breve'}
-              </button>
-            </div>
-          </div>
+            <p className="genre-card__desc">{genre.description}</p>
+            <Button variant="secondary" onClick={() => navigate(`/genres/${genre.id}`)}>
+              Abrir
+            </Button>
+          </article>
         ))}
       </div>
     </div>

--- a/frontend/src/pages/HomePage.css
+++ b/frontend/src/pages/HomePage.css
@@ -1,0 +1,85 @@
+.home-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.home-header p {
+  color: var(--color-text-muted);
+}
+
+.home-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.home-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.home-stat__num {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.home-stat span:last-child {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.home-continue {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--color-success-bg);
+}
+
+.home-continue__label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-accent-600);
+}
+
+.home-generos__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.home-genero-card {
+  text-align: left;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  cursor: pointer;
+}
+
+.home-genero-card__desc {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 720px) {
+  .home-stats {
+    grid-template-columns: 1fr;
+  }
+  .home-continue {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -29,9 +29,14 @@ export default function HomePage() {
           fetch(`${API_BASE_URL}/genres`, { headers: { ...authHeader() } })
         ]);
         if (!rPerfil.ok || !rProgresso.ok || !rGeneros.ok) throw new Error('Falha ao carregar');
-        setPerfil(await rPerfil.json());
-        setProgresso(await rProgresso.json());
-        setGeneros(await rGeneros.json());
+        const [dadosPerfil, dadosProgresso, dadosGeneros] = await Promise.all([
+          rPerfil.json(),
+          rProgresso.json(),
+          rGeneros.json()
+        ]);
+        setPerfil(dadosPerfil);
+        setProgresso(dadosProgresso);
+        setGeneros(dadosGeneros);
       } catch (e) {
         console.error(e);
         setErro(true);

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -18,9 +18,7 @@ export default function HomePage() {
   const [loading, setLoading] = useState(true);
   const [erro, setErro] = useState(false);
 
-  const carregar = async () => {
-    setLoading(true);
-    setErro(false);
+  const fetchDados = async () => {
     try {
       const [rPerfil, rProgresso, rGeneros] = await Promise.all([
         fetch(`${API_BASE_URL}/users/me`, { headers: { ...authHeader() } }),
@@ -39,10 +37,16 @@ export default function HomePage() {
     }
   };
 
-  useEffect(() => { carregar(); }, []);
+  useEffect(() => { fetchDados(); }, []);
+
+  const handleRetry = () => {
+    setLoading(true);
+    setErro(false);
+    fetchDados();
+  };
 
   if (loading) return <LoadingState message="Carregando início..." />;
-  if (erro || !perfil || !progresso) return <ErrorState message="Não foi possível carregar o início." onRetry={carregar} />;
+  if (erro || !perfil || !progresso) return <ErrorState message="Não foi possível carregar o início." onRetry={handleRetry} />;
 
   const emProgresso = progresso.byGenre.find(g => g.totalPhases > 0 && g.completedPhases < g.totalPhases)
     || progresso.byGenre.find(g => g.totalPhases > 0);

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -18,32 +18,37 @@ export default function HomePage() {
   const [loading, setLoading] = useState(true);
   const [erro, setErro] = useState(false);
 
-  const fetchDados = async () => {
-    try {
-      const [rPerfil, rProgresso, rGeneros] = await Promise.all([
-        fetch(`${API_BASE_URL}/users/me`, { headers: { ...authHeader() } }),
-        fetch(`${API_BASE_URL}/users/me/progress`, { headers: { ...authHeader() } }),
-        fetch(`${API_BASE_URL}/genres`, { headers: { ...authHeader() } })
-      ]);
-      if (!rPerfil.ok || !rProgresso.ok || !rGeneros.ok) throw new Error('Falha ao carregar');
-      setPerfil(await rPerfil.json());
-      setProgresso(await rProgresso.json());
-      setGeneros(await rGeneros.json());
-    } catch (e) {
-      console.error(e);
-      setErro(true);
-    } finally {
-      setLoading(false);
-    }
-  };
+  const [retryCount, setRetryCount] = useState(0);
 
-  useEffect(() => { fetchDados(); }, []);
+  useEffect(() => {
+    const carregar = async () => {
+      try {
+        const [rPerfil, rProgresso, rGeneros] = await Promise.all([
+          fetch(`${API_BASE_URL}/users/me`, { headers: { ...authHeader() } }),
+          fetch(`${API_BASE_URL}/users/me/progress`, { headers: { ...authHeader() } }),
+          fetch(`${API_BASE_URL}/genres`, { headers: { ...authHeader() } })
+        ]);
+        if (!rPerfil.ok || !rProgresso.ok || !rGeneros.ok) throw new Error('Falha ao carregar');
+        setPerfil(await rPerfil.json());
+        setProgresso(await rProgresso.json());
+        setGeneros(await rGeneros.json());
+      } catch (e) {
+        console.error(e);
+        setErro(true);
+      } finally {
+        setLoading(false);
+      }
+    };
+    carregar();
+  }, [retryCount]);
 
   const handleRetry = () => {
     setLoading(true);
     setErro(false);
-    fetchDados();
+    setRetryCount(c => c + 1);
   };
+
+
 
   if (loading) return <LoadingState message="Carregando início..." />;
   if (erro || !perfil || !progresso) return <ErrorState message="Não foi possível carregar o início." onRetry={handleRetry} />;

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { authHeader } from '../utils/auth';
+import Card from '../components/ui/Card';
+import Button from '../components/ui/Button';
+import GenreBadge from '../components/ui/GenreBadge';
+import LoadingState from '../components/ui/LoadingState';
+import ErrorState from '../components/ui/ErrorState';
+import './HomePage.css';
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+export default function HomePage() {
+  const navigate = useNavigate();
+  const [perfil, setPerfil] = useState(null);
+  const [progresso, setProgresso] = useState(null);
+  const [generos, setGeneros] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [erro, setErro] = useState(false);
+
+  const carregar = async () => {
+    setLoading(true);
+    setErro(false);
+    try {
+      const [rPerfil, rProgresso, rGeneros] = await Promise.all([
+        fetch(`${API_BASE_URL}/users/me`, { headers: { ...authHeader() } }),
+        fetch(`${API_BASE_URL}/users/me/progress`, { headers: { ...authHeader() } }),
+        fetch(`${API_BASE_URL}/genres`, { headers: { ...authHeader() } })
+      ]);
+      if (!rPerfil.ok || !rProgresso.ok || !rGeneros.ok) throw new Error('Falha ao carregar');
+      setPerfil(await rPerfil.json());
+      setProgresso(await rProgresso.json());
+      setGeneros(await rGeneros.json());
+    } catch (e) {
+      console.error(e);
+      setErro(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { carregar(); }, []);
+
+  if (loading) return <LoadingState message="Carregando início..." />;
+  if (erro || !perfil || !progresso) return <ErrorState message="Não foi possível carregar o início." onRetry={carregar} />;
+
+  const emProgresso = progresso.byGenre.find(g => g.totalPhases > 0 && g.completedPhases < g.totalPhases)
+    || progresso.byGenre.find(g => g.totalPhases > 0);
+
+  return (
+    <div className="home-page">
+      <header className="home-header">
+        <h1>Olá, {perfil.name}</h1>
+        <p>Continue de onde parou ou explore um novo gênero.</p>
+      </header>
+
+      <div className="home-stats">
+        <Card className="home-stat"><span className="home-stat__num">{perfil.xp}</span><span>XP acumulado</span></Card>
+        <Card className="home-stat"><span className="home-stat__num">{progresso.totalCompletedPhases}</span><span>Fases concluídas</span></Card>
+        <Card className="home-stat"><span className="home-stat__num">Nível {perfil.level}</span><span>Nível atual</span></Card>
+      </div>
+
+      {emProgresso && (
+        <Card className="home-continue">
+          <div>
+            <span className="home-continue__label">Continue de onde parou</span>
+            <h2>{emProgresso.genreName}</h2>
+            <p>{emProgresso.completedPhases} de {emProgresso.totalPhases} fases concluídas</p>
+          </div>
+          <Button variant="secondary" onClick={() => navigate(`/genres/${emProgresso.genreId}`)}>
+            Continuar leitura
+          </Button>
+        </Card>
+      )}
+
+      <section className="home-generos">
+        <h2>Explorar gêneros</h2>
+        <div className="home-generos__grid">
+          {generos.map((g) => (
+            <button key={g.id} className="home-genero-card" onClick={() => navigate(`/genres/${g.id}`)}>
+              <GenreBadge slug={g.slug}>{g.name}</GenreBadge>
+              <span className="home-genero-card__desc">{g.description}</span>
+            </button>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/auth.css
+++ b/frontend/src/pages/auth.css
@@ -6,7 +6,7 @@
 
 .auth-left {
   flex: 1.7;
-  background-color: #4b3fa0;
+  background-color: var(--color-primary);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -38,6 +38,7 @@
 }
 
 .auth-tagline {
+  font-family: var(--font-display);
   font-size: 1.3rem;
   font-weight: 700;
   line-height: 1.3;
@@ -54,7 +55,7 @@
 
 .auth-right {
   flex: 1;
-  background-color: #f5f0eb;
+  background-color: var(--color-bg);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -63,9 +64,10 @@
 }
 
 .auth-title {
+  font-family: var(--font-display);
   font-size: 2rem;
   font-weight: 700;
-  color: #4b3fa0;
+  color: var(--color-primary);
   margin-bottom: 8px;
   width: 100%;
   max-width: 400px;
@@ -73,14 +75,14 @@
 
 .auth-subtitle {
   font-size: 0.9rem;
-  color: #666;
+  color: var(--color-text-muted);
   margin-bottom: 32px;
   width: 100%;
   max-width: 400px;
 }
 
 .auth-subtitle a {
-  color: #4b3fa0;
+  color: var(--color-primary);
   text-decoration: none;
   font-weight: 500;
 }
@@ -103,30 +105,30 @@
   font-size: 0.75rem;
   font-weight: 600;
   letter-spacing: 0.08em;
-  color: #555;
+  color: var(--color-text-muted);
 }
 
 .auth-input {
-  color: #666;
+  color: var(--color-text);
   padding: 14px 16px;
-  border: 1px solid #ddd;
-  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   font-size: 1rem;
-  background: white;
+  background: var(--color-surface);
   outline: none;
   transition: border-color 0.2s;
 }
 
 .auth-input:focus {
-  border-color: #4b3fa0;
+  border-color: var(--color-primary);
 }
 
 .auth-btn-primary {
   padding: 14px;
-  background-color: #4b3fa0;
+  background-color: var(--color-primary);
   color: white;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-sm);
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
@@ -134,15 +136,15 @@
 }
 
 .auth-btn-primary:hover {
-  background-color: #3a2f80;
+  background-color: var(--color-primary-700);
 }
 
 .auth-btn-secondary {
   padding: 14px;
   background-color: transparent;
-  color: #4b3fa0;
-  border: 2px solid #4b3fa0;
-  border-radius: 8px;
+  color: var(--color-primary);
+  border: 2px solid var(--color-primary);
+  border-radius: var(--radius-sm);
   font-size: 1rem;
   font-weight: 600;
   cursor: pointer;
@@ -151,14 +153,14 @@
 }
 
 .auth-btn-secondary:hover {
-  background-color: rgba(75, 63, 160, 0.08);
+  background-color: rgba(58, 47, 128, 0.08);
 }
 
 .auth-divider {
   display: flex;
   align-items: center;
   gap: 12px;
-  color: #aaa;
+  color: var(--color-text-muted);
   font-size: 0.85rem;
 }
 
@@ -167,12 +169,12 @@
   content: '';
   flex: 1;
   height: 1px;
-  background-color: #ddd;
+  background-color: var(--color-border);
 }
 
 /* ── Erro ── */
 .auth-error {
-  color: #e53e3e;
+  color: var(--color-danger);
   font-size: 0.875rem;
 }
 

--- a/frontend/src/routes/AppRoutes.jsx
+++ b/frontend/src/routes/AppRoutes.jsx
@@ -10,6 +10,7 @@ import PhaseCompletedPage from '../pages/PhaseCompletedPage';
 import PrivateRoute from "./PrivateRoute";
 import Layout from '../components/Layout';
 import ProfilePage from '../pages/ProfilePage';
+import HomePage from '../pages/HomePage';
 
 export const AppRoutes = () => {
   return (
@@ -17,6 +18,17 @@ export const AppRoutes = () => {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
+
+        <Route
+          path="/inicio"
+          element={
+            <PrivateRoute>
+              <Layout>
+                <HomePage />
+              </Layout>
+            </PrivateRoute>
+          }
+        />
 
         <Route
           path="/genres"
@@ -87,6 +99,7 @@ export const AppRoutes = () => {
           }
         />
 
+        <Route path="/" element={<Navigate to="/inicio" />} />
         <Route path="*" element={<Navigate to="/login" />} />
       </Routes>
     </BrowserRouter>


### PR DESCRIPTION
## Descrição

> Alinha login e cadastro aos tokens do design system, faz a GenresPage consumir o backend /genres (removendo o array hardcoded) e cria a página inicial Home com saudação, estatísticas, continuar de onde parou e exploração de gêneros. A navegação por gênero passa a usar o id numérico.

> Por quê: a tela de gêneros usava dados fixos e não havia página inicial conforme os wireframes.

Closes #128 

---

## Tipo de Mudança

- [x] Nova funcionalidade
- [ ] Correção de bug 
- [ ] Melhoria de código
- [ ] Documentação 
- [ ] Testes
- [ ] Configuração/infraestrutura

---

## Como Testar

1. Garantir que o design system (M1) e o endpoint de progresso (A3) estão na main
2. Rodar npm run dev e fazer login, conferindo que cai na Home
3. Na Home, conferir saudação, XP, fases concluídas, nível e continuar de onde parou
4. Em Livros, conferir que os gêneros vêm do backend e abrem a trilha pelo id numérico
5. Rodar npm run build

**Resultado esperado:**  auth tokenizado, gêneros vindos do backend e Home funcionando

---

## Checklist

- [ ] Código compila e executa sem erros
- [ ] Testes adicionados/atualizados e passando
- [ ] Padrões de código seguidos (lint/formatação)
- [x] Commits seguem Conventional Commits
- [x] Branch atualizada com `develop`