### PR TITLE
fix(ui): trilha de fases em zigue-zague com conector tracejado

### DIFF
--- a/frontend/src/pages/PhaseListPage.css
+++ b/frontend/src/pages/PhaseListPage.css
@@ -33,31 +33,35 @@
   color: var(--color-text-muted);
 }
 
-.trilha-lista {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
+.trilha-mapa {
+  position: relative;
+  margin: 0 auto;
+  max-width: 100%;
+}
+
+.trilha-conector {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.trilha-conector polyline {
+  fill: none;
+  stroke: var(--color-border);
+  stroke-width: 2;
+  stroke-dasharray: 5 7;
+  stroke-linecap: round;
 }
 
 .trilha-no {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.5rem 0;
-  position: relative;
-}
-
-.trilha-no:not(:last-child)::before {
-  content: '';
   position: absolute;
-  left: 27px;
-  top: 56px;
-  width: 2px;
-  height: calc(100% - 8px);
-  background: var(--color-border);
+  transform: translateX(-50%);
+  width: 120px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  text-align: center;
 }
 
 .trilha-no__circulo {

--- a/frontend/src/pages/PhaseListPage.jsx
+++ b/frontend/src/pages/PhaseListPage.jsx
@@ -48,6 +48,17 @@ export default function PhaseListPage() {
     if (phase.isUnlocked) navigate(`/reading/${phase.id}/1`);
   };
 
+  const larguraTrilha = 300;
+  const alturaLinha = 112;
+  const raioCirculo = 28;
+  const margemTopo = 16;
+  const faixaX = [88, 212];
+  const centroX = (i) => faixaX[i % 2];
+  const topoNo = (i) => margemTopo + i * alturaLinha;
+  const centroY = (i) => topoNo(i) + raioCirculo;
+  const alturaTrilha = margemTopo + phases.length * alturaLinha + 48;
+  const pontos = phases.map((_, i) => `${centroX(i)},${centroY(i)}`).join(' ');
+
   return (
     <div className="trilha-page">
       <header className="trilha-header">
@@ -62,11 +73,24 @@ export default function PhaseListPage() {
         </Button>
       </header>
 
-      <ol className="trilha-lista">
-        {phases.map((phase) => {
+      <div className="trilha-mapa" style={{ width: larguraTrilha, height: alturaTrilha }}>
+        <svg
+          className="trilha-conector"
+          viewBox={`0 0 ${larguraTrilha} ${alturaTrilha}`}
+          width={larguraTrilha}
+          height={alturaTrilha}
+          aria-hidden="true"
+        >
+          <polyline points={pontos} />
+        </svg>
+        {phases.map((phase, i) => {
           const estado = phase.isCompleted ? 'concluida' : phase.isUnlocked ? 'ativa' : 'bloqueada';
           return (
-            <li key={phase.id} className={`trilha-no trilha-no--${estado}`}>
+            <div
+              key={phase.id}
+              className={`trilha-no trilha-no--${estado}`}
+              style={{ left: centroX(i), top: topoNo(i) }}
+            >
               <button
                 className="trilha-no__circulo"
                 onClick={() => irParaFase(phase)}
@@ -75,10 +99,10 @@ export default function PhaseListPage() {
                 {phase.isCompleted ? '✓' : phase.isUnlocked ? phase.phaseNumber : '🔒'}
               </button>
               <span className="trilha-no__titulo">{phase.title}</span>
-            </li>
+            </div>
           );
         })}
-      </ol>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/ProfilePage.css
+++ b/frontend/src/pages/ProfilePage.css
@@ -43,6 +43,7 @@
 .profile-header h1 {
   margin: 0 0 0.25rem;
   font-size: 1.6rem;
+  color: inherit;
 }
 
 .profile-header p {


### PR DESCRIPTION
## Descrição

> O que foi feito e por quê:

  A trilha de fases estava sendo renderizada como uma coluna reta, com todos os nós alinhados à esquerda e ligados por uma única linha vertical. O esperado é um caminho em zigue-zague.

  Closes #141 

  ---
  Tipo de Mudança

  - [ ] Nova funcionalidade
  - [x] Correção de bug
  - [ ] Melhoria de código
  - [ ] Documentação
  - [ ] Testes
  - [ ] Configuração/infraestrutura

  ---
  Como Testar

  1. Logar no app e abrir a trilha de fases do gênero Aventura (/genres/{genero}).
  2. Observar a disposição dos nós e a linha que os conecta.

  Resultado esperado: os nós aparecem em zigue-zague (alternando esquerda/direita) e a linha que os liga é tracejada, diagonal e sem ponta de seta. Os estados das fases (concluída, ativa, bloqueada) e o clique continuam funcionando como antes.

  ---
  Checklist

  - [x] Código compila e executa sem erros
  - [ ] Testes adicionados/atualizados e passando
  - [x] Padrões de código seguidos (lint/formatação)
  - [x] Commits seguem Conventional Commits
  - [ ] Branch atualizada com develop