### PR TITLE
ci(frontend): adiciona npm test ao job frontend-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Rodar lint
         working-directory: ./frontend
         run: npm run lint
+      - name: Rodar testes do frontend
+        working-directory: ./frontend
+        run: npm test -- --run
       - name: Verificar build
         working-directory: ./frontend
         run: npm run build


### PR DESCRIPTION
  ## Descrição

  Adiciona o passo `npm test -- --run` ao job `frontend-build` do CI, entre o lint e o build, para que regressões de 
  teste no frontend sejam detectadas automaticamente no pipeline.

  Por que: a avaliação da Entrega 7 apontou que o CI não executava `npm test` no frontend. O teste do ReadingPage já    
  está verde localmente (11 testes passando), então esta mudança cobre apenas a lacuna do pipeline.

  Closes #148

  ---
  ## Tipo de Mudança

  - [ ] Nova funcionalidade
  - [ ] Correção de bug
  - [ ] Melhoria de código
  - [ ] Documentação
  - [x] Testes
  - [x] Configuração/infraestrutura

  ---
  ## Como Testar

  1. Conferir que o job `frontend-build` passou a ter três passos: lint, testes e build
  2. Confirmar que o passo "Rodar testes do frontend" executa `npm test -- --run` e fica verde
  3. Localmente: `cd frontend && npm test -- --run` deve passar (11 testes)

  Resultado esperado: pipeline verde com o novo passo de testes.

  ---
  ## Checklist

  - [x] Código compila e executa sem erros
  - [x] Testes adicionados/atualizados e passando
  - [x] Padrões de código seguidos (lint/formatação)
  - [x] Commits seguem Conventional Commits
  - [x] Branch atualizada com main