### PR TITLE
fix(backend): completa contrato de erro com handlers 500 e 403

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -109,6 +109,13 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -Dnet.bytebuddy.experimental=true</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.11</version>

--- a/backend/src/main/java/com/librum/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/librum/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.librum.exception;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -35,5 +36,17 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleNotFound(EntityNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(Map.of("message", ex.getMessage()));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(Map.of("message", "Acesso negado a este recurso"));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGenerico(Exception ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("message", "Erro interno do servidor"));
     }
 }

--- a/backend/src/main/java/com/librum/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/librum/exception/GlobalExceptionHandler.java
@@ -1,18 +1,22 @@
 package com.librum.exception;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.Map;
 
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(DuplicateEmailException.class)
     public ResponseEntity<Map<String, String>> handleDuplicateEmail(DuplicateEmailException ex) {
@@ -26,12 +30,6 @@ public class GlobalExceptionHandler {
                 .body(Map.of("message", "E-mail ou senha incorretos"));
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, String>> handleValidation(MethodArgumentNotValidException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                .body(Map.of("message", "Campos obrigatorios invalidos"));
-    }
-
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<Map<String, String>> handleNotFound(EntityNotFoundException ex) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
@@ -42,6 +40,27 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(Map.of("message", "Acesso negado a este recurso"));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers,
+                                                                  HttpStatusCode status,
+                                                                  WebRequest request) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", "Campos obrigatorios invalidos"));
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex,
+                                                             Object body,
+                                                             HttpHeaders headers,
+                                                             HttpStatusCode statusCode,
+                                                             WebRequest request) {
+        String message = statusCode.is4xxClientError()
+                ? "Requisicao invalida"
+                : "Erro interno do servidor";
+        return ResponseEntity.status(statusCode).body(Map.of("message", message));
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/test/java/com/librum/controller/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/librum/controller/AuthControllerIntegrationTest.java
@@ -1,0 +1,38 @@
+package com.librum.controller;
+
+import com.librum.security.JwtUtil;
+import com.librum.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@Import(com.librum.security.SecurityConfig.class)
+public class AuthControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @Test
+    void login_comJsonMalformado_retorna400() throws Exception {
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{ invalido"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").exists());
+    }
+}

--- a/backend/src/test/java/com/librum/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/librum/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,27 @@
+package com.librum.exception;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleGenerico_retorna500ComMensagem() {
+        var resposta = handler.handleGenerico(new RuntimeException("detalhe interno"));
+
+        assertThat(resposta.getStatusCode().value()).isEqualTo(500);
+        assertThat(resposta.getBody().get("message")).isEqualTo("Erro interno do servidor");
+    }
+
+    @Test
+    void handleAccessDenied_retorna403ComMensagem() {
+        var resposta = handler.handleAccessDenied(new AccessDeniedException("bloqueada"));
+
+        assertThat(resposta.getStatusCode().value()).isEqualTo(403);
+        assertThat(resposta.getBody().get("message")).isNotBlank();
+    }
+}


### PR DESCRIPTION
  ## Descrição

  Completa o GlobalExceptionHandler adicionando handlers para falha inesperada (500) e acesso negado (403), garantindo que todo erro responda no formato { message } esperado pelo frontend. Inclui testes unitarios para os dois novos handlers e a flag experimental do Byte Buddy para compatibilidade com Java 25.

  Closes #155

  ---

  ## Tipo de Mudança

  - [ ] Nova funcionalidade
  - [ ] Correção de bug
  - [x] Melhoria de código
  - [ ] Documentação
  - [x] Testes
  - [ ] Configuração/infraestrutura

  ---

  ## Como Testar

  1. Rodar `cd backend && ./mvnw test`
  2. Verificar que `GlobalExceptionHandlerTest` passa com 2 testes verdes

  **Resultado esperado:** todos os testes do backend passando, sem erros de Byte Buddy

  ---

  ## Checklist

  - [x] Código compila e executa sem erros
  - [x] Testes adicionados/atualizados e passando
  - [x] Padrões de código seguidos (lint/formatação)
  - [x] Commits seguem Conventional Commits
  - [ ] Branch atualizada com `develop`
