### PR TITLE
feat(auth): carregamento e mensagens do Tinta na autenticacao

### DIFF
--- a/frontend/src/components/auth/LoginForm.jsx
+++ b/frontend/src/components/auth/LoginForm.jsx
@@ -2,23 +2,27 @@ import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { login } from '../../services/authService';
 import { useAuth } from '../../context/useAuth';
+import { mensagemDoTinta, carregandoTinta } from '../../utils/tintaMessages';
 
 const LoginForm = () => {
   const [credentials, setCredentials] = useState({ email: '', password: '' });
-
   const [error, setError] = useState('');
+  const [carregando, setCarregando] = useState(false);
   const { loginUser } = useAuth();
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
+    setCarregando(true);
     try {
       const data = await login(credentials.email, credentials.password);
       loginUser(data);
       navigate('/inicio');
     } catch (err) {
-      setError(err.message || 'E-mail ou senha incorretos');
+      setError(mensagemDoTinta(err));
+    } finally {
+      setCarregando(false);
     }
   };
 
@@ -48,7 +52,9 @@ const LoginForm = () => {
 
       {error && <p className="auth-error">{error}</p>}
 
-      <button className="auth-btn-primary" type="submit">Entrar</button>
+      <button className="auth-btn-primary" type="submit" disabled={carregando}>
+        {carregando ? carregandoTinta.login : 'Entrar'}
+      </button>
       <Link to="/register">
         <button className="auth-btn-secondary" type="button">Criar conta</button>
       </Link>

--- a/frontend/src/components/auth/RegisterForm.jsx
+++ b/frontend/src/components/auth/RegisterForm.jsx
@@ -2,10 +2,12 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { register } from '../../services/authService';
 import { useAuth } from '../../context/useAuth';
+import { mensagemDoTinta, carregandoTinta } from '../../utils/tintaMessages';
 
 const RegisterForm = () => {
   const [data, setData] = useState({ name: '', email: '', password: '', confirmPassword: '' });
   const [error, setError] = useState('');
+  const [carregando, setCarregando] = useState(false);
   const navigate = useNavigate();
   const { loginUser } = useAuth();
 
@@ -23,12 +25,15 @@ const RegisterForm = () => {
       return;
     }
 
+    setCarregando(true);
     try {
       const response = await register(data.name, data.email, data.password);
       loginUser({ userId: response.userId, token: response.token });
       navigate('/inicio');
     } catch (err) {
-      setError(err.message || 'Erro no cadastro');
+      setError(mensagemDoTinta(err));
+    } finally {
+      setCarregando(false);
     }
   };
 
@@ -80,7 +85,9 @@ const RegisterForm = () => {
 
       {error && <p className="auth-error">{error}</p>}
 
-      <button className="auth-btn-primary" type="submit">Criar conta</button>
+      <button className="auth-btn-primary" type="submit" disabled={carregando}>
+        {carregando ? carregandoTinta.cadastro : 'Criar conta'}
+      </button>
     </form>
   );
 };

--- a/frontend/src/services/authService.js
+++ b/frontend/src/services/authService.js
@@ -1,5 +1,20 @@
 const API_URL = `${import.meta.env.VITE_API_URL}/auth`;
 
+const lerCorpo = async (response) => {
+  const text = await response.text();
+  try {
+    return text ? JSON.parse(text) : {};
+  } catch {
+    return {};
+  }
+};
+
+const erroComStatus = (status) => {
+  const err = new Error('falha na autenticacao');
+  err.status = status;
+  return err;
+};
+
 export const register = async (name, email, password) => {
   const response = await fetch(`${API_URL}/register`, {
     method: 'POST',
@@ -7,13 +22,8 @@ export const register = async (name, email, password) => {
     body: JSON.stringify({ name, email, password }),
   });
 
-  const text = await response.text();
-  const data = text ? JSON.parse(text) : {};
-
-  if (!response.ok) {
-    throw new Error(data.message || 'Erro ao cadastrar');
-  }
-
+  const data = await lerCorpo(response);
+  if (!response.ok) throw erroComStatus(response.status);
   return data;
 };
 
@@ -24,11 +34,7 @@ export const login = async (email, password) => {
     body: JSON.stringify({ email, password }),
   });
 
-  const data = await response.json();
-
-  if (!response.ok) {
-    throw new Error(data.message || 'Erro ao fazer login');
-  }
-
+  const data = await lerCorpo(response);
+  if (!response.ok) throw erroComStatus(response.status);
   return data;
 };


### PR DESCRIPTION
## Descrição

Adiciona indicador de carregamento no botão de login e no de cadastro durante a requisição, e substitui as mensagens de erro técnicas por mensagens na voz do mascote Tinta. O `authService` foi reescrito para anexar o status HTTP ao erro lançado e para lidar com respostas não-JSON (como o HTML retornado pelo 503 do Render em cold start), permitindo que o catálogo `tintaMessages.js` selecione a mensagem certa para cada situação.

Closes #151 

---

## Tipo de Mudança

- [x] Nova funcionalidade
- [ ] Correção de bug 
- [ ] Melhoria de código
- [ ] Documentação 
- [ ] Testes
- [ ] Configuração/infraestrutura

---

## Como Testar

1. Acesse a tela de login e tente entrar com e-mail ou senha incorretos.
2. Com o backend fora do ar (ou desligado localmente), tente fazer login ou criar conta.

**Resultado esperado:** o botão mostra o texto do Tinta durante o carregamento e fica desabilitado; após a resposta, aparece a mensagem do Tinta correspondente ao erro (credenciais, sem conexão, servidor cochilando, etc.).

---

## Checklist

- [x] Código compila e executa sem erros
- [x] Testes adicionados/atualizados e passando
- [x] Padrões de código seguidos (lint/formatação)
- [x] Commits seguem Conventional Commits
- [x] Branch atualizada com `develop`