### PR TITLE
Feat/feedback generos home

### DIFF
--- a/frontend/src/pages/GenresPage.jsx
+++ b/frontend/src/pages/GenresPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authHeader } from '../utils/auth';
+import { mensagemDoTinta } from '../utils/tintaMessages';
 import Button from '../components/ui/Button';
 import GenreBadge from '../components/ui/GenreBadge';
 import LoadingState from '../components/ui/LoadingState';
@@ -20,7 +21,7 @@ export default function GenresPage() {
   const navigate = useNavigate();
   const [genres, setGenres] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [erro, setErro] = useState(false);
+  const [erro, setErro] = useState('');
 
   const [retryCount, setRetryCount] = useState(0);
 
@@ -30,11 +31,15 @@ export default function GenresPage() {
         const response = await fetch(`${API_BASE_URL}/genres`, {
           headers: { ...authHeader() },
         });
-        if (!response.ok) throw new Error('Falha ao carregar generos');
+        if (!response.ok) {
+          const err = new Error('falha ao carregar generos');
+          err.status = response.status;
+          throw err;
+        }
         setGenres(await response.json());
       } catch (e) {
         console.error(e);
-        setErro(true);
+        setErro(mensagemDoTinta(e));
       } finally {
         setLoading(false);
       }
@@ -44,14 +49,14 @@ export default function GenresPage() {
 
   const handleRetry = () => {
     setLoading(true);
-    setErro(false);
+    setErro('');
     setRetryCount(c => c + 1);
   };
 
 
 
   if (loading) return <LoadingState message="Carregando gêneros..." />;
-  if (erro) return <ErrorState message="Não foi possível carregar os gêneros." onRetry={handleRetry} />;
+  if (erro) return <ErrorState message={erro} onRetry={handleRetry} />;
 
   return (
     <div className="genres-page">

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authHeader } from '../utils/auth';
+import { mensagemDoTinta } from '../utils/tintaMessages';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
 import GenreBadge from '../components/ui/GenreBadge';
@@ -16,7 +17,7 @@ export default function HomePage() {
   const [progresso, setProgresso] = useState(null);
   const [generos, setGeneros] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [erro, setErro] = useState(false);
+  const [erro, setErro] = useState('');
 
   const [retryCount, setRetryCount] = useState(0);
 
@@ -28,7 +29,12 @@ export default function HomePage() {
           fetch(`${API_BASE_URL}/users/me/progress`, { headers: { ...authHeader() } }),
           fetch(`${API_BASE_URL}/genres`, { headers: { ...authHeader() } })
         ]);
-        if (!rPerfil.ok || !rProgresso.ok || !rGeneros.ok) throw new Error('Falha ao carregar');
+        if (!rPerfil.ok || !rProgresso.ok || !rGeneros.ok) {
+          const resposta = [rPerfil, rProgresso, rGeneros].find(r => !r.ok);
+          const err = new Error('falha ao carregar inicio');
+          err.status = resposta.status;
+          throw err;
+        }
         const [dadosPerfil, dadosProgresso, dadosGeneros] = await Promise.all([
           rPerfil.json(),
           rProgresso.json(),
@@ -39,7 +45,7 @@ export default function HomePage() {
         setGeneros(dadosGeneros);
       } catch (e) {
         console.error(e);
-        setErro(true);
+        setErro(mensagemDoTinta(e));
       } finally {
         setLoading(false);
       }
@@ -49,14 +55,14 @@ export default function HomePage() {
 
   const handleRetry = () => {
     setLoading(true);
-    setErro(false);
+    setErro('');
     setRetryCount(c => c + 1);
   };
 
 
 
   if (loading) return <LoadingState message="Carregando início..." />;
-  if (erro || !perfil || !progresso) return <ErrorState message="Não foi possível carregar o início." onRetry={handleRetry} />;
+  if (erro || !perfil || !progresso) return <ErrorState message={erro || mensagemDoTinta({})} onRetry={handleRetry} />;
 
   const emProgresso = progresso.byGenre.find(g => g.totalPhases > 0 && g.completedPhases < g.totalPhases)
     || progresso.byGenre.find(g => g.totalPhases > 0);


### PR DESCRIPTION
## Descrição

Aplica o catálogo do Tinta no tratamento de erro das páginas de Gêneros e Home. O `fetch` de cada página agora anexa o status HTTP ao erro antes de lançá-lo, e o `catch` passa o erro para `mensagemDoTinta`, exibindo a frase certa do mascote no `ErrorState` em vez de uma mensagem fixa genérica.

Closes #152 

---

## Tipo de Mudança

- [ ] Nova funcionalidade
- [ ] Correção de bug 
- [x] Melhoria de código
- [ ] Documentação 
- [ ] Testes
- [ ] Configuração/infraestrutura

---

## Como Testar

1. Com o backend fora do ar, acesse a página de Gêneros — deve aparecer a mensagem do Tinta de sem conexão ou servidor cochilando.
2. Com o backend rodando, acesse a Home normalmente — deve carregar sem erros.

**Resultado esperado:** em caso de falha, o `ErrorState` exibe a mensagem do Tinta correspondente ao tipo de erro, com o botão "Tentar de novo" funcionando.

---

## Checklist

- [x] Código compila e executa sem erros
- [ ] Testes adicionados/atualizados e passando
- [x] Padrões de código seguidos (lint/formatação)
- [x] Commits seguem Conventional Commits
- [x] Branch atualizada com `develop`
