### PR TITLE
test(ui): cobre catalogo do Tinta e componentes de feedback

### DIFF
--- a/frontend/src/components/ui/Button.test.jsx
+++ b/frontend/src/components/ui/Button.test.jsx
@@ -24,4 +24,9 @@ describe('Button', () => {
     render(<Button full>Entrar</Button>);
     expect(screen.getByText('Entrar')).toHaveClass('btn--full');
   });
+  it('fica desabilitado e mostra carregamento quando loading é true', () => {
+    render(<Button loading>Processando</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+    // O spinner esta presente, podemos tentar ver se o texto ou spinner aparecem (dependendo da implementacao), mas desabilitar e o basico testavel via DOM.
+  });
 });

--- a/frontend/src/components/ui/Button.test.jsx
+++ b/frontend/src/components/ui/Button.test.jsx
@@ -25,8 +25,8 @@ describe('Button', () => {
     expect(screen.getByText('Entrar')).toHaveClass('btn--full');
   });
   it('fica desabilitado e mostra carregamento quando loading é true', () => {
-    render(<Button loading>Processando</Button>);
+    const { container } = render(<Button loading>Processando</Button>);
     expect(screen.getByRole('button')).toBeDisabled();
-    // O spinner esta presente, podemos tentar ver se o texto ou spinner aparecem (dependendo da implementacao), mas desabilitar e o basico testavel via DOM.
+    expect(container.querySelector('.btn__spinner')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/ui/ErrorState.test.jsx
+++ b/frontend/src/components/ui/ErrorState.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ErrorState from './ErrorState';
+
+describe('ErrorState', () => {
+  it('renderiza a mensagem de erro fornecida', () => {
+    render(<ErrorState message="Uma mensagem customizada de erro" />);
+    expect(screen.getByText('Uma mensagem customizada de erro')).toBeInTheDocument();
+  });
+
+  it('chama onRetry quando o botao é clicado', () => {
+    const handleRetry = vi.fn();
+    render(<ErrorState message="Erro ao carregar" onRetry={handleRetry} />);
+    
+    const retryButton = screen.getByRole('button', { name: /tentar de novo/i });
+    fireEvent.click(retryButton);
+    
+    expect(handleRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/utils/tintaMessages.test.js
+++ b/frontend/src/utils/tintaMessages.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { mensagemDoTinta } from './tintaMessages';
+
+describe('mensagemDoTinta', () => {
+  it('sem status retorna mensagem de sem conexao', () => {
+    expect(mensagemDoTinta({})).toMatch(/internet/i);
+  });
+
+  it('401 fala de e-mail e senha', () => {
+    expect(mensagemDoTinta({ status: 401 })).toMatch(/e-mail e senha/i);
+  });
+
+  it('403 fala de parte trancada', () => {
+    expect(mensagemDoTinta({ status: 403 })).toMatch(/trancada/i);
+  });
+
+  it('409 fala de e-mail ja cadastrado', () => {
+    expect(mensagemDoTinta({ status: 409 })).toMatch(/ja tem uma conta/i);
+  });
+
+  it('503 fala de biblioteca cochilando', () => {
+    expect(mensagemDoTinta({ status: 503 })).toMatch(/cochilando/i);
+  });
+
+  it('500 cai na mensagem de erro do servidor', () => {
+    expect(mensagemDoTinta({ status: 500 })).toMatch(/lado da biblioteca/i);
+  });
+
+  it('status desconhecido cai no fallback', () => {
+    expect(mensagemDoTinta({ status: 418 })).toMatch(/mais uma tentativa/i);
+  });
+});


### PR DESCRIPTION
Descricao

> Cobre com testes automatizados o catalogo do Tinta e os componentes de feedback criados no Bloco M1.

Closes #165

---
Tipo de Mudanca

- [ ] Nova funcionalidade
- [ ] Melhoria de codigo
- [ ] Correcao de bug
- [ ] Documentacao
- [x] Testes
- [ ] Configuracao/infraestrutura

---
Como Testar

1. npm test -- --run no frontend
2. Verificar cobertura de tintaMessages e de Button/ErrorState.

---
Checklist

- [ ] Codigo compila e executa sem erros
- [x] Padroes de codigo seguidos (lint)
- [x] Commits seguem Conventional Commits
- [ ] Branch atualizada com main
