### PR TITLE
feat(quiz): carregamento e mensagens do Tinta no quiz e fase concluida

### DIFF
--- a/frontend/src/pages/QuizPage.css
+++ b/frontend/src/pages/QuizPage.css
@@ -201,6 +201,15 @@
   cursor: not-allowed;
 }
 
+.quiz-erro-envio {
+  align-self: flex-end;
+  margin: 0;
+  color: var(--color-danger, #c2483d);
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-align: right;
+}
+
 .quiz-reference {
   border-radius: var(--radius-md, 14px);
   padding: 1rem 1.25rem;

--- a/frontend/src/pages/QuizPage.jsx
+++ b/frontend/src/pages/QuizPage.jsx
@@ -4,6 +4,7 @@ import { QuizService } from '../services/QuizService';
 import MascotBubble from '../components/ui/MascotBubble';
 import LoadingState from '../components/ui/LoadingState';
 import ErrorState from '../components/ui/ErrorState';
+import { mensagemDoTinta, carregandoTinta } from '../utils/tintaMessages';
 import mascotePensativo from '../assets/mascots/librum-pensativo.svg';
 import './QuizPage.css';
 
@@ -17,7 +18,7 @@ const QuizPage = () => {
   const { phaseId } = useParams();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
-  const [erro, setErro] = useState(false);
+  const [erro, setErro] = useState(null);
   const [answers, setAnswers] = useState([]);
   const [results, setResults] = useState([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
@@ -34,7 +35,7 @@ const QuizPage = () => {
         setQuestionsData(data);
       } catch (error) {
         console.error('Erro ao carregar o quiz:', error);
-        setErro(true);
+        setErro(mensagemDoTinta(error));
       } finally {
         setLoading(false);
       }
@@ -43,7 +44,7 @@ const QuizPage = () => {
   }, [phaseId]);
 
   if (loading) return <LoadingState message="Carregando quiz..." />;
-  if (erro) return <ErrorState message="Não foi possível carregar o quiz." />;
+  if (erro) return <ErrorState message={erro} />;
   if (!questionsData || questionsData.length === 0) {
     return <ErrorState message="Nenhuma questão encontrada para esta fase." />;
   }
@@ -81,7 +82,8 @@ const QuizPage = () => {
       navigate(`/quiz/${phaseId}/fase-concluida`, { state: result });
     } catch (error) {
       console.error('Erro ao enviar quiz:', error);
-      alert('Houve um erro ao enviar suas respostas.');
+      setErro(mensagemDoTinta(error));
+    } finally {
       setSubmitting(false);
     }
   };
@@ -153,9 +155,11 @@ const QuizPage = () => {
                   onClick={handleNext}
                   disabled={submitting}
                 >
-                  {currentQuestionIndex < questionsData.length - 1
-                    ? 'Próxima questão →'
-                    : 'Ver resultado →'}
+                  {submitting
+                    ? carregandoTinta.quiz
+                    : currentQuestionIndex < questionsData.length - 1
+                      ? 'Próxima questão →'
+                      : 'Ver resultado →'}
                 </button>
               )}
             </div>

--- a/frontend/src/pages/QuizPage.jsx
+++ b/frontend/src/pages/QuizPage.jsx
@@ -4,7 +4,7 @@ import { QuizService } from '../services/QuizService';
 import MascotBubble from '../components/ui/MascotBubble';
 import LoadingState from '../components/ui/LoadingState';
 import ErrorState from '../components/ui/ErrorState';
-import { mensagemDoTinta, carregandoTinta } from '../utils/tintaMessages';
+import { mensagemDoTinta, carregandoTinta, vazioTinta } from '../utils/tintaMessages';
 import mascotePensativo from '../assets/mascots/librum-pensativo.svg';
 import './QuizPage.css';
 
@@ -26,6 +26,7 @@ const QuizPage = () => {
   const [feedback, setFeedback] = useState(null);
   const [questionsData, setQuestionsData] = useState([]);
   const [submitting, setSubmitting] = useState(false);
+  const [erroEnvio, setErroEnvio] = useState(null);
 
   useEffect(() => {
     const fetchQuestions = async () => {
@@ -43,10 +44,10 @@ const QuizPage = () => {
     fetchQuestions();
   }, [phaseId]);
 
-  if (loading) return <LoadingState message="Carregando quiz..." />;
+  if (loading) return <LoadingState message={carregandoTinta.generico} />;
   if (erro) return <ErrorState message={erro} />;
   if (!questionsData || questionsData.length === 0) {
-    return <ErrorState message="Nenhuma questão encontrada para esta fase." />;
+    return <ErrorState message={vazioTinta.quiz} />;
   }
 
   const currentQuestion = questionsData[currentQuestionIndex];
@@ -78,11 +79,12 @@ const QuizPage = () => {
   const submitFinalQuiz = async (finalAnswers) => {
     try {
       setSubmitting(true);
+      setErroEnvio(null);
       const result = await QuizService.submitQuiz(phaseId, finalAnswers);
       navigate(`/quiz/${phaseId}/fase-concluida`, { state: result });
     } catch (error) {
       console.error('Erro ao enviar quiz:', error);
-      setErro(mensagemDoTinta(error));
+      setErroEnvio(mensagemDoTinta(error));
     } finally {
       setSubmitting(false);
     }
@@ -161,6 +163,10 @@ const QuizPage = () => {
                       ? 'Próxima questão →'
                       : 'Ver resultado →'}
                 </button>
+              )}
+
+              {erroEnvio && (
+                <p className="quiz-erro-envio" role="alert">{erroEnvio}</p>
               )}
             </div>
 

--- a/frontend/src/services/QuizService.js
+++ b/frontend/src/services/QuizService.js
@@ -7,7 +7,11 @@ export const QuizService = {
     const response = await fetch(`${API_BASE_URL}/quiz/${phaseId}`, {
       headers: { ...authHeader() }
     });
-    if (!response.ok) throw new Error('Falha ao carregar as questões');
+    if (!response.ok) {
+      const err = new Error('falha ao carregar as questoes');
+      err.status = response.status;
+      throw err;
+    }
     return await response.json();
   },
 
@@ -20,7 +24,11 @@ export const QuizService = {
       },
       body: JSON.stringify({ answers })
     });
-    if (!response.ok) throw new Error('Falha ao enviar o quiz');
+    if (!response.ok) {
+      const err = new Error('falha ao enviar o quiz');
+      err.status = response.status;
+      throw err;
+    }
     return await response.json();
   }
 };

--- a/frontend/src/utils/tintaMessages.js
+++ b/frontend/src/utils/tintaMessages.js
@@ -26,3 +26,7 @@ export const carregandoTinta = {
   quiz: 'O Tinta esta corrigindo suas respostas...',
   generico: 'So um instante, o Tinta esta buscando...',
 };
+
+export const vazioTinta = {
+  quiz: 'O Tinta nao achou questoes para esta fase. Tente novamente mais tarde.',
+};


### PR DESCRIPTION
## Descrição

Adiciona indicador de carregamento ao enviar o quiz e substitui as mensagens de erro técnicas por mensagens na voz do mascote Tinta no QuizPage. O `QuizService` agora anexa o status HTTP ao erro nos dois métodos, permitindo que o catálogo `tintaMessages.js` selecione a mensagem certa. O `PhaseCompletedPage` foi revisado: é uma página apenas de exibição dos dados recebidos por navegação, sem chamada de API, então não há tratamento de erro a aplicar nela.

Closes #167

---

## Tipo de Mudança

- [ ] Nova funcionalidade
- [ ] Correção de bug
- [x] Melhoria de código
- [ ] Documentação
- [ ] Testes
- [ ] Configuração/infraestrutura

---

## Como Testar

1. `cd frontend && npm run lint && npm test -- --run` verdes.
2. Responder um quiz e, ao enviar, observar o botão mostrando "O Tinta esta corrigindo suas respostas..." desabilitado durante a submissão.
3. Com o backend fora do ar, abrir um quiz e tentar enviar; o erro aparece na voz do Tinta (sem conexão / servidor cochilando) no ErrorState.

**Resultado esperado:** envio do quiz com feedback de carregamento e erros sempre na voz do Tinta; nenhuma mensagem técnica crua.

---

## Checklist

- [x] Código compila e executa sem erros
- [x] Testes adicionados/atualizados e passando
- [x] Padrões de código seguidos (lint/formatação)
- [x] Commits seguem Conventional Commits
- [ ] Branch atualizada com \`main\`